### PR TITLE
Refactor simple timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pdx
+*.code-workspace

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "playdate",
+      "request": "launch",
+      "name": "Playdate: Debug",
+      "preLaunchTask": "${defaultBuildTask}"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,25 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "pdc",
+      "problemMatcher": ["$pdc-lua", "$pdc-external"],
+      "label": "Playdate: Build"
+    },
+    {
+      "type": "playdate-simulator",
+      "problemMatcher": ["$pdc-external"],
+      "label": "Playdate: Run"
+    },
+    {
+      "label": "Playdate: Build and Run",
+      "dependsOn": ["Playdate: Build", "Playdate: Run"],
+      "dependsOrder": "sequence",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # pomdate
 Pomodoro timer for Playdate
+
+## WIP; coming soon

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,4 @@
+-- Project-wide constants
+
+W_SCREEN = 400; W_CENTRE = 200
+H_SCREEN = 240; H_CENTRE = 120

--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,0 @@
--- Project-wide constants
-
-W_SCREEN = 400; W_CENTRE = 200
-H_SCREEN = 240; H_CENTRE = 120

--- a/configs.lua
+++ b/configs.lua
@@ -1,0 +1,11 @@
+-- Project-wide constants
+
+local exported = {
+    name = "configs",
+    W_SCREEN = 400, W_CENTRE = 200,
+    H_SCREEN = 240, H_CENTRE = 120
+}
+
+configs = utils.makeReadOnly(exported)
+
+return configs

--- a/debugger.lua
+++ b/debugger.lua
@@ -1,0 +1,61 @@
+import "CoreLibs/timer"
+
+local pd <const> = playdate
+local gfx = pd.graphics
+
+-- TODO test scope of these vars by attempting to mod them from another file
+local W_SCREEN = 400
+local H_SCREEN = 240
+local W_LEFT_MARGIN <const> = 2
+local H_LINE <const> = 16
+local NUM_LINES <const> = 15 -- 240/16 (screen height / line height)
+
+-- Debugger generates and draws a message log image
+class('Debugger').extends()
+
+-- Debugger:init() initializes a new Debugger
+function Debugger:init()
+    -- TODO test scope of these vars by attempting to mod them from another file
+    self.img = playdate.graphics.image.new(400, 240)    -- img containing debug log
+    self.cMsgs = 0                                       -- logged message count
+
+    print("debugger init")
+end
+
+-- Debugger:log(message) adds text to the debug log
+-- Messages are prepended by the message count at the time of logging
+-- Returns current message count
+-- Log is drawn upon calling Debugger:draw()
+function Debugger:log(msg)
+    self.cMsgs = self.cMsgs + 1
+
+    local iLine = math.fmod(self.cMsgs - 1, NUM_LINES) -- index of current line to draw
+    local xpos = W_LEFT_MARGIN
+    local ypos = iLine * H_LINE
+
+    gfx.pushContext(self.img) -- not sure if this is needed
+        gfx.setColor(gfx.kColorClear)
+        gfx.fillRect(xpos, ypos, W_SCREEN, H_LINE) -- clear the current line
+        gfx.setColor(gfx.kColorBlack)
+        gfx.drawText(self.cMsgs .. ": " .. msg, xpos, ypos)
+    gfx.popContext()
+
+    return self.cMsgs
+end
+
+-- Debugger:draw() draws the log image in white pixels, for ease of use in debugDraw
+function Debugger:draw()
+    gfx.pushContext()
+        gfx.setImageDrawMode(gfx.kDrawModeInverted)
+        self.img:draw(0,0)
+    gfx.popContext()
+end
+
+-- Debugger:clear() clears the log image of all content
+-- Avoid using if possible. Inconvenient special effects.
+-- TODO could modify to clear message at a specific index
+function Debugger:clear(iMsg)
+    gfx.pushContext(self.img)
+        gfx.clear()
+    gfx.popContext()
+end

--- a/debugger.lua
+++ b/debugger.lua
@@ -11,71 +11,80 @@ local W_LEFT_MARGIN <const> = 2
 local H_LINE <const> = 16
 local NUM_LINES <const> = 15 -- 240/16 (screen height / line height)
 
--- TODO set disableDebugger flag
+-- TODO disableDebugger flag
 
--- Debugger generates and draws a message log image.
-class('Debugger').extends()
+local logImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing debug log
+local cMsgs = 0                                      -- logged message count
+local illImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing illustrations
 
--- Debugger:init() initializes a new Debugger
-function Debugger:init()
-    -- TODO test scope of these vars by attempting to mod them from another file
-    self.logImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing debug log
-    self.cMsgs = 0                                      -- logged message count
-    self.illImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing illustrations
+debugger = {
+    -- log(message) adds text to the debug log.
+    -- Messages are prepended by the message count at the time of logging.
+    -- Returns current message count.
+    -- Log is drawn upon calling debugger.draw()
+    log = function (msg)
+        cMsgs = cMsgs + 1
+        local logText = cMsgs .. ": " .. msg
 
-    print("debugger init")
-end
+        local iLine = math.fmod(cMsgs - 1, NUM_LINES) -- index of current line to draw
+        local xpos = W_LEFT_MARGIN
+        local ypos = iLine * H_LINE
 
--- Debugger:log(message) adds text to the debug log.
--- Messages are prepended by the message count at the time of logging.
--- Returns current message count.
--- Log is drawn upon calling Debugger:draw()
-function Debugger:log(msg)
-    self.cMsgs = self.cMsgs + 1
-    local logText = self.cMsgs .. ": " .. msg
+        print(logText)
+        gfx.pushContext(logImg)
+            gfx.setColor(gfx.kColorClear)
+            gfx.fillRect(xpos, ypos, W_SCREEN, H_LINE) -- clear the current line
+            gfx.setColor(gfx.kColorBlack)
+            gfx.drawText(logText, xpos, ypos)
+        gfx.popContext()
 
-    local iLine = math.fmod(self.cMsgs - 1, NUM_LINES) -- index of current line to draw
-    local xpos = W_LEFT_MARGIN
-    local ypos = iLine * H_LINE
+        return cMsgs
+    end,
 
-    print(logText)
-    gfx.pushContext(self.logImg)
-        gfx.setColor(gfx.kColorClear)
-        gfx.fillRect(xpos, ypos, W_SCREEN, H_LINE) -- clear the current line
-        gfx.setColor(gfx.kColorBlack)
-        gfx.drawText(logText, xpos, ypos)
-    gfx.popContext()
+    -- draw() draws the debug log image in black pixels.
+    -- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
+    --  visualization by pd.debugDraw()
+    drawLog = function ()
+        logImg:draw(0,0)
+    end,
+    
+    -- clearLog() clears the log image of all content.
+    -- Avoid using if possible. Inconvenient special effects.
+    -- TODO could modify to clear message at a specific index
+    clearLog = function ()
+        gfx.pushContext(logImg)
+            gfx.clear()
+        gfx.popContext()
+    end,
 
-    return self.cMsgs
-end
+    -- bounds(sprite) visualizes the rectangular bounds of the sprite
+    bounds = function (sprite)
+        gfx.pushContext(illImg)
+            gfx.drawRect(sprite:getBounds())
+        gfx.popContext()
+    end,
 
--- Debugger:draw() draws the debug log image in black pixels.
--- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
---  visualization by pd.debugDraw()
-function Debugger:drawLog()
-    self.logImg:draw(0,0)
-end
+    -- drawIllustrations() draws the debug illustrations image in black pixels.
+    -- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
+    --  visualization by pd.debugDraw()
+    drawIllustrations = function ()
+        illImg:draw(0,0)
+    end,
 
--- Debugger:draw() draws the debug illustrations image in black pixels.
--- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
---  visualization by pd.debugDraw()
-function Debugger:drawIllustrations()
-    self.illImg:draw(0,0)
-end
-
-
--- Debugger:clear() clears the log image of all content.
--- Avoid using if possible. Inconvenient special effects.
--- TODO could modify to clear message at a specific index
-function Debugger:clear()
-    gfx.pushContext(self.img)
-        gfx.clear()
-    gfx.popContext()
-end
+    -- clearIllustrations() clears the log image of all content.
+    -- Avoid using if possible. Inconvenient special effects.
+    -- TODO could modify to clear message at a specific index
+    clearIllustrations = function ()
+        gfx.pushContext(logImg)
+            gfx.clear()
+        gfx.popContext()
+    end
+}
 
 
-function Debugger:bounds(sprite)
-    gfx.pushContext(self.illImg)
-        gfx.drawRect(sprite:getBounds())
-    gfx.popContext()
-end
+
+
+
+
+
+

--- a/debugger.lua
+++ b/debugger.lua
@@ -6,85 +6,113 @@ import "config"
 local pd <const> = playdate
 local gfx <const> = pd.graphics
 
--- TODO test scope of these vars by attempting to mod them from another file
 local W_LEFT_MARGIN <const> = 2
 local H_LINE <const> = 16
 local NUM_LINES <const> = 15 -- 240/16 (screen height / line height)
 
--- TODO disableDebugger flag
-
-local logImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing debug log
 local cMsgs = 0                                      -- logged message count
+local logImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing log
 local illImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing illustrations
+local enabled = false                                -- false by default. true if debugger is enabled
 
-debugger = {
-    -- log(message) adds text to the debug log.
-    -- Messages are prepended by the message count at the time of logging.
-    -- Returns current message count.
-    -- Log is drawn upon calling debugger.draw()
-    log = function (msg)
-        cMsgs = cMsgs + 1
-        local logText = cMsgs .. ": " .. msg
+-- log(message) adds text to the debug log.
+-- Messages are prepended by the message count at the time of logging.
+-- Returns current message count.
+-- Log is drawn upon calling debugger.draw()
+local function log (msg)
+    cMsgs = cMsgs + 1
+    local logText = cMsgs .. ": " .. msg
 
-        local iLine = math.fmod(cMsgs - 1, NUM_LINES) -- index of current line to draw
-        local xpos = W_LEFT_MARGIN
-        local ypos = iLine * H_LINE
+    local iLine = math.fmod(cMsgs - 1, NUM_LINES) -- index of current line to draw
+    local xpos = W_LEFT_MARGIN
+    local ypos = iLine * H_LINE
 
-        print(logText)
-        gfx.pushContext(logImg)
-            gfx.setColor(gfx.kColorClear)
-            gfx.fillRect(xpos, ypos, W_SCREEN, H_LINE) -- clear the current line
-            gfx.setColor(gfx.kColorBlack)
-            gfx.drawText(logText, xpos, ypos)
-        gfx.popContext()
+    print(logText)
+    gfx.pushContext(logImg)
+        gfx.setColor(gfx.kColorClear)
+        gfx.fillRect(xpos, ypos, W_SCREEN, H_LINE) -- clear the current line
+        gfx.setColor(gfx.kColorBlack)
+        gfx.drawText(logText, xpos, ypos)
+    gfx.popContext()
 
-        return cMsgs
+    return cMsgs
+end
+
+-- clearLog() clears the log image of all content.
+-- Avoid using if possible. Inconvenient special effects.
+-- TODO could modify to clear message at a specific index
+local function clearLog ()
+    gfx.pushContext(logImg)
+        gfx.clear()
+    gfx.popContext()
+end
+
+-- drawLog() draws the debug log image in black pixels.
+-- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
+--  visualization by pd.debugDraw()
+local function drawLog ()
+    logImg:draw(0,0)
+end
+
+-- bounds(sprite) visualizes the rectangular bounds of the sprite
+local function bounds (sprite)
+    gfx.pushContext(illImg)
+        gfx.drawRect(sprite:getBounds())
+    gfx.popContext()
+end
+
+-- clearIllustrations() clears the log image of all content.
+-- Avoid using if possible. Inconvenient special effects.
+-- TODO could modify to clear message at a specific index
+local function clearIllustrations ()
+    gfx.pushContext(logImg)
+        gfx.clear()
+    gfx.popContext()
+end
+
+-- drawIllustrations() draws the debug illustrations image in black pixels.
+-- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
+--  visualization by pd.debugDraw()
+local function drawIllustrations ()
+    illImg:draw(0,0)
+end
+
+
+-- debugger is actually a mostly-empty middle layer between
+--      - mt: the access metatable, and 
+--      - exported: the table of exported functions and values
+local exported = {
+    log = log,
+    clearLog = clearLog,
+    drawLog = drawLog,
+    bounds = bounds,
+    clearIllustrations = clearIllustrations,
+    drawIllustrations = drawIllustrations,
+}
+local mt = {
+    __index = function(t,k)
+        if enabled then 
+            return exported[k] 
+        else 
+            return function (...) end -- do nothing but remain callable
+        end
     end,
-
-    -- draw() draws the debug log image in black pixels.
-    -- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
-    --  visualization by pd.debugDraw()
-    drawLog = function ()
-        logImg:draw(0,0)
-    end,
-    
-    -- clearLog() clears the log image of all content.
-    -- Avoid using if possible. Inconvenient special effects.
-    -- TODO could modify to clear message at a specific index
-    clearLog = function ()
-        gfx.pushContext(logImg)
-            gfx.clear()
-        gfx.popContext()
-    end,
-
-    -- bounds(sprite) visualizes the rectangular bounds of the sprite
-    bounds = function (sprite)
-        gfx.pushContext(illImg)
-            gfx.drawRect(sprite:getBounds())
-        gfx.popContext()
-    end,
-
-    -- drawIllustrations() draws the debug illustrations image in black pixels.
-    -- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
-    --  visualization by pd.debugDraw()
-    drawIllustrations = function ()
-        illImg:draw(0,0)
-    end,
-
-    -- clearIllustrations() clears the log image of all content.
-    -- Avoid using if possible. Inconvenient special effects.
-    -- TODO could modify to clear message at a specific index
-    clearIllustrations = function ()
-        gfx.pushContext(logImg)
-            gfx.clear()
-        gfx.popContext()
+    __newindex = function(t,k,v)
+        log("Forbidden to write to debugger pkg")
     end
 }
+debugger = {
+    -- setEnabled(bool) enables or disables *all functionality* of the debugger
+    setEnabled = function (bool)
+        if bool then
+            enabled = true
+            print("debugger enabled")
+        else
+            enabled = false
+            print("debugger disabled")
+        end
+    end
+}
+setmetatable(debugger, mt)
 
-
-
-
-
-
-
-
+return debugger

--- a/debugger.lua
+++ b/debugger.lua
@@ -1,61 +1,81 @@
-import "CoreLibs/timer"
+import "CoreLibs/object"
+import "CoreLibs/graphics"
+
+import "config"
 
 local pd <const> = playdate
-local gfx = pd.graphics
+local gfx <const> = pd.graphics
 
 -- TODO test scope of these vars by attempting to mod them from another file
-local W_SCREEN = 400
-local H_SCREEN = 240
 local W_LEFT_MARGIN <const> = 2
 local H_LINE <const> = 16
 local NUM_LINES <const> = 15 -- 240/16 (screen height / line height)
 
--- Debugger generates and draws a message log image
+-- TODO set disableDebugger flag
+
+-- Debugger generates and draws a message log image.
 class('Debugger').extends()
 
 -- Debugger:init() initializes a new Debugger
 function Debugger:init()
     -- TODO test scope of these vars by attempting to mod them from another file
-    self.img = playdate.graphics.image.new(400, 240)    -- img containing debug log
-    self.cMsgs = 0                                       -- logged message count
+    self.logImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing debug log
+    self.cMsgs = 0                                      -- logged message count
+    self.illImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing illustrations
 
     print("debugger init")
 end
 
--- Debugger:log(message) adds text to the debug log
--- Messages are prepended by the message count at the time of logging
--- Returns current message count
+-- Debugger:log(message) adds text to the debug log.
+-- Messages are prepended by the message count at the time of logging.
+-- Returns current message count.
 -- Log is drawn upon calling Debugger:draw()
 function Debugger:log(msg)
     self.cMsgs = self.cMsgs + 1
+    local logText = self.cMsgs .. ": " .. msg
 
     local iLine = math.fmod(self.cMsgs - 1, NUM_LINES) -- index of current line to draw
     local xpos = W_LEFT_MARGIN
     local ypos = iLine * H_LINE
 
-    gfx.pushContext(self.img) -- not sure if this is needed
+    print(logText)
+    gfx.pushContext(self.logImg)
         gfx.setColor(gfx.kColorClear)
         gfx.fillRect(xpos, ypos, W_SCREEN, H_LINE) -- clear the current line
         gfx.setColor(gfx.kColorBlack)
-        gfx.drawText(self.cMsgs .. ": " .. msg, xpos, ypos)
+        gfx.drawText(logText, xpos, ypos)
     gfx.popContext()
 
     return self.cMsgs
 end
 
--- Debugger:draw() draws the log image in white pixels, for ease of use in debugDraw
-function Debugger:draw()
-    gfx.pushContext()
-        gfx.setImageDrawMode(gfx.kDrawModeInverted)
-        self.img:draw(0,0)
+-- Debugger:draw() draws the debug log image in black pixels.
+-- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
+--  visualization by pd.debugDraw()
+function Debugger:drawLog()
+    self.logImg:draw(0,0)
+end
+
+-- Debugger:draw() draws the debug illustrations image in black pixels.
+-- Call gfx.setImageDrawMode(gfx.kDrawModeInverted) prior to this func for
+--  visualization by pd.debugDraw()
+function Debugger:drawIllustrations()
+    self.illImg:draw(0,0)
+end
+
+
+-- Debugger:clear() clears the log image of all content.
+-- Avoid using if possible. Inconvenient special effects.
+-- TODO could modify to clear message at a specific index
+function Debugger:clear()
+    gfx.pushContext(self.img)
+        gfx.clear()
     gfx.popContext()
 end
 
--- Debugger:clear() clears the log image of all content
--- Avoid using if possible. Inconvenient special effects.
--- TODO could modify to clear message at a specific index
-function Debugger:clear(iMsg)
-    gfx.pushContext(self.img)
-        gfx.clear()
+
+function Debugger:bounds(sprite)
+    gfx.pushContext(self.illImg)
+        gfx.drawRect(sprite:getBounds())
     gfx.popContext()
 end

--- a/debugger.lua
+++ b/debugger.lua
@@ -2,6 +2,7 @@ import "CoreLibs/object"
 import "CoreLibs/graphics"
 
 import "config"
+import "utils"
 
 local pd <const> = playdate
 local gfx <const> = pd.graphics
@@ -94,14 +95,13 @@ local mt = {
         if enabled then 
             return exported[k] 
         else 
+            -- TODO try removing ... below
             return function (...) end -- do nothing but remain callable
         end
-    end,
-    __newindex = function(t,k,v)
-        log("Forbidden to write to debugger pkg")
     end
 }
 debugger = {
+    name = "debugger",
     -- setEnabled(bool) enables or disables *all functionality* of the debugger
     setEnabled = function (bool)
         if bool then
@@ -114,5 +114,6 @@ debugger = {
     end
 }
 setmetatable(debugger, mt)
+makeReadOnly(debugger)
 
 return debugger

--- a/debugger.lua
+++ b/debugger.lua
@@ -1,10 +1,4 @@
-import "CoreLibs/object"
-import "CoreLibs/graphics"
-
-import "config"
-import "utils"
-
-local pd <const> = playdate
+local pd <const> = playdate -- _G.playdate etc
 local gfx <const> = pd.graphics
 
 local W_LEFT_MARGIN <const> = 2

--- a/debugger.lua
+++ b/debugger.lua
@@ -1,5 +1,7 @@
 local pd <const> = playdate -- _G.playdate etc
 local gfx <const> = pd.graphics
+local W_SCREEN = configs.W_SCREEN
+local H_SCREEN = configs.H_SCREEN
 
 local W_LEFT_MARGIN <const> = 2
 local H_LINE <const> = 16
@@ -8,7 +10,8 @@ local NUM_LINES <const> = 15 -- 240/16 (screen height / line height)
 local cMsgs = 0                                      -- logged message count
 local logImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing log
 local illImg = gfx.image.new(W_SCREEN, H_SCREEN)     -- img containing illustrations
-local enabled = false                                -- false by default. true if debugger is enabled
+local enabled = true                                 -- true by default. true if debugger is enabled
+
 
 -- log(message) adds text to the debug log.
 -- Messages are prepended by the message count at the time of logging.
@@ -77,37 +80,32 @@ end
 --      - mt: the access metatable, and 
 --      - exported: the table of exported functions and values
 local exported = {
+    name = "debugger",
     log = log,
     clearLog = clearLog,
     drawLog = drawLog,
     bounds = bounds,
     clearIllustrations = clearIllustrations,
-    drawIllustrations = drawIllustrations,
+    drawIllustrations = drawIllustrations
+}
+local readonly = utils.makeReadOnly(exported)
+debugger = {
+    disable = function()
+        enabled = false
+        print("debugger disabled")
+    end
 }
 local mt = {
     __index = function(t,k)
-        if enabled then 
-            return exported[k] 
+        if enabled then
+            return readonly[k]
         else 
             -- TODO try removing ... below
             return function (...) end -- do nothing but remain callable
         end
-    end
-}
-debugger = {
-    name = "debugger",
-    -- setEnabled(bool) enables or disables *all functionality* of the debugger
-    setEnabled = function (bool)
-        if bool then
-            enabled = true
-            print("debugger enabled")
-        else
-            enabled = false
-            print("debugger disabled")
-        end
-    end
+    end,
+    __newindex = readonly
 }
 setmetatable(debugger, mt)
-makeReadOnly(debugger)
 
 return debugger

--- a/main.lua
+++ b/main.lua
@@ -1,76 +1,48 @@
 import "CoreLibs/object"
 import "CoreLibs/graphics"
 import "CoreLibs/sprites"
-import "CoreLibs/timer"
 
 import "debugger"
+import "timer"
 
+-- TODO move to config??
 local pd <const> = playdate
 local gfx <const> = pd.graphics
 local A <const> = pd.kButtonA
 
-local SEC_PER_MIN <const> = 60
-
 --local font = nil
-local targetSeconds = nil
 local debugger = nil
 
+local workTimer = nil; local workMinutes = nil
+
 -- changing images does change the appearance of sprites using that image
-local timerImg = nil
-local instructorImg = nil
-local notifImg = nil
-
-local timerSprite = nil
-local instructorSprite = nil
-local notifSprite = nil
-
-local function countdown()
-    return math.max(targetSeconds - pd.getElapsedTime(), 0)
-end
+local instructorImg = nil; local instructorSprite = nil
 
 -- init() sets up our game environment.
 local function init()
     debugger = Debugger()
 
-    targetSeconds = 0.1 * SEC_PER_MIN -- 25 mins
+    workMinutes = 0.1
+    workTimer = Timer(50, 50, debugger)
+    workTimer:add()
 
     -- TODO encapsulate all sprites below into classes
 
-    timerImg = gfx.image.new(400, 16)
-    notifImg = gfx.image.new(400, 16)
-    instructorImg = gfx.image.new(400, 16)
+    instructorImg = gfx.image.new(W_SCREEN, 16)
 
     gfx.lockFocus(instructorImg)
         gfx.drawText("press A to reset timer", 0, 0)
     gfx.unlockFocus()
 
-    -- need to add smth to sprite list to initialize it prior to drawing anything
+    -- need to add smth to sprite list to initialize it prior to gfx.draw()ing anything
     -- sprite must have size to be drawn
-    instructorSprite = gfx.sprite.new(instructorImg)
-    notifSprite = gfx.sprite.new(notifImg)
-    timerSprite = gfx.sprite.new(timerImg)
-
---[[
-        :update() is called before :draw is called on all sprites
-        Suspected conditions for redrawing a sprite if getAlwaysRedraw() == false
-            - associated gfx.image has changed
-            - sprite has had some transform applied to it
-        So if we need to update a sprite every frame, do something in its :update()
---]]
-    function timerSprite:update()
-        gfx.lockFocus(timerImg)
-            gfx.clear()
-            gfx.drawText(countdown(), 160, 0)
-        gfx.unlockFocus()
-    end
-
     -- moveTo moves sprite by its anchor point, defaulted to centre of sprite size
-    instructorSprite:moveTo(200, 16)
+    instructorSprite = gfx.sprite.new(instructorImg)
+    instructorSprite:setCenter(0, 0)
     instructorSprite:add()
-    timerSprite:moveTo(200, 120)
-    timerSprite:add()
-    notifSprite:moveTo(200, 150)
-    notifSprite:add()
+
+    workTimer:start(workMinutes)
+
 end
 
 init()
@@ -78,15 +50,19 @@ init()
 -- update() is called right before every frame is drawn onscreen.
 function pd.update()
     if pd.buttonJustPressed(A) then
-        pd.resetElapsedTime()
-        debugger:log("timer reset")
+        workTimer:reset()
     end
 
+    pd.timer.updateTimers()
     gfx.sprite.update()
 end
 
 -- debugDraw() is called immediately after update()
 -- Only white pixels are drawn; black transparent
 function pd.debugDraw()
-    debugger:draw()
+    gfx.pushContext()
+        gfx.setImageDrawMode(gfx.kDrawModeInverted)
+        debugger:drawLog()
+        debugger:drawIllustrations()
+    gfx.popContext()
 end

--- a/main.lua
+++ b/main.lua
@@ -10,9 +10,6 @@ local pd <const> = playdate
 local gfx <const> = pd.graphics
 local A <const> = pd.kButtonA
 
---local font = nil
-local debugger = nil
-
 local workTimer = nil; local workMinutes = nil
 
 -- changing images does change the appearance of sprites using that image
@@ -20,10 +17,8 @@ local instructorImg = nil; local instructorSprite = nil
 
 -- init() sets up our game environment.
 local function init()
-    debugger = Debugger()
-
     workMinutes = 0.1
-    workTimer = Timer(50, 50, debugger)
+    workTimer = Timer(50, 50)
     workTimer:add()
 
     -- TODO encapsulate all sprites below into classes
@@ -42,7 +37,6 @@ local function init()
     instructorSprite:add()
 
     workTimer:start(workMinutes)
-
 end
 
 init()
@@ -62,7 +56,7 @@ end
 function pd.debugDraw()
     gfx.pushContext()
         gfx.setImageDrawMode(gfx.kDrawModeInverted)
-        debugger:drawLog()
-        debugger:drawIllustrations()
+        debugger.drawLog()
+        debugger.drawIllustrations()
     gfx.popContext()
 end

--- a/main.lua
+++ b/main.lua
@@ -17,6 +17,8 @@ local instructorImg = nil; local instructorSprite = nil
 
 -- init() sets up our game environment.
 local function init()
+    debugger.setEnabled(true)
+    
     workMinutes = 0.1
     workTimer = Timer(50, 50)
     workTimer:add()

--- a/main.lua
+++ b/main.lua
@@ -15,10 +15,10 @@ local workTimer = nil; local workMinutes = nil
 -- changing images does change the appearance of sprites using that image
 local instructorImg = nil; local instructorSprite = nil
 
+debugger.setEnabled(true)
+
 -- init() sets up our game environment.
 local function init()
-    debugger.setEnabled(true)
-    
     workMinutes = 0.1
     workTimer = Timer(50, 50)
     workTimer:add()

--- a/main.lua
+++ b/main.lua
@@ -1,7 +1,10 @@
+-- if multiple packages need the same import, put that import here
+-- todo write or install a tool to verify that there are no redundant imports in the proj
 import "CoreLibs/object"
 import "CoreLibs/graphics"
-import "CoreLibs/sprites"
 
+import "config"
+import "utils"
 import "debugger"
 import "timer"
 

--- a/main.lua
+++ b/main.lua
@@ -3,6 +3,8 @@ import "CoreLibs/graphics"
 import "CoreLibs/sprites"
 import "CoreLibs/timer"
 
+import "debugger"
+
 local pd <const> = playdate
 local gfx <const> = pd.graphics
 local A <const> = pd.kButtonA
@@ -10,15 +12,14 @@ local A <const> = pd.kButtonA
 local SEC_PER_MIN <const> = 60
 
 --local font = nil
---local targetSec = nil
+local targetSeconds = nil
+local debugger = nil
 
 -- changing images does change the appearance of sprites using that image
-local debugImg = nil
 local timerImg = nil
 local instructorImg = nil
 local notifImg = nil
 
-local debugSprite = nil
 local timerSprite = nil
 local instructorSprite = nil
 local notifSprite = nil
@@ -27,14 +28,14 @@ local function countdown()
     return math.max(targetSeconds - pd.getElapsedTime(), 0)
 end
 
--- init sets up our game environment.
+-- init() sets up our game environment.
 local function init()
+    debugger = Debugger()
+
     targetSeconds = 0.1 * SEC_PER_MIN -- 25 mins
 
     -- TODO encapsulate all sprites below into classes
-    -- incl. the debugger
 
-    debugImg = gfx.image.new(400, 16)
     timerImg = gfx.image.new(400, 16)
     notifImg = gfx.image.new(400, 16)
     instructorImg = gfx.image.new(400, 16)
@@ -45,7 +46,6 @@ local function init()
 
     -- need to add smth to sprite list to initialize it prior to drawing anything
     -- sprite must have size to be drawn
-    debugSprite = gfx.sprite.new(debugImg)
     instructorSprite = gfx.sprite.new(instructorImg)
     notifSprite = gfx.sprite.new(notifImg)
     timerSprite = gfx.sprite.new(timerImg)
@@ -56,8 +56,6 @@ local function init()
             - associated gfx.image has changed
             - sprite has had some transform applied to it
         So if we need to update a sprite every frame, do something in its :update()
-        TODO try setting a class var for timerSprite that we update here and print 
-            in :draw(). See if that marks it to be redrawn every frame
 --]]
     function timerSprite:update()
         gfx.lockFocus(timerImg)
@@ -73,28 +71,22 @@ local function init()
     timerSprite:add()
     notifSprite:moveTo(200, 150)
     notifSprite:add()
-    debugSprite:setZIndex(100)
-    debugSprite:moveTo(200, 224)
-    debugSprite:add()
 end
 
 init()
 
--- update is called right before every frame is drawn onscreen.
+-- update() is called right before every frame is drawn onscreen.
 function pd.update()
-    if pd.buttonIsPressed(A) then
+    if pd.buttonJustPressed(A) then
         pd.resetElapsedTime()
-
-        gfx.lockFocus(debugImg)
-            gfx.clear()
-            gfx.drawText("timer reset", 0, 0)
-        gfx.unlockFocus()
-    else
-        gfx.lockFocus(debugImg)
-            gfx.clear()
-        gfx.unlockFocus()
+        debugger:log("timer reset")
     end
 
-    -- failing to call timerSprite:draw()
     gfx.sprite.update()
+end
+
+-- debugDraw() is called immediately after update()
+-- Only white pixels are drawn; black transparent
+function pd.debugDraw()
+    debugger:draw()
 end

--- a/main.lua
+++ b/main.lua
@@ -3,12 +3,11 @@
 import "CoreLibs/object"
 import "CoreLibs/graphics"
 
-import "config"
 import "utils"
+import "configs"
 import "debugger"
 import "timer"
 
--- TODO move to config??
 local pd <const> = playdate
 local gfx <const> = pd.graphics
 local A <const> = pd.kButtonA
@@ -18,17 +17,18 @@ local workTimer = nil; local workMinutes = nil
 -- changing images does change the appearance of sprites using that image
 local instructorImg = nil; local instructorSprite = nil
 
-debugger.setEnabled(true)
-
 -- init() sets up our game environment.
 local function init()
+    --utils.disableReadOnly()
+    --debugger.disable()
+
     workMinutes = 0.1
     workTimer = Timer(50, 50)
     workTimer:add()
 
     -- TODO encapsulate all sprites below into classes
 
-    instructorImg = gfx.image.new(W_SCREEN, 16)
+    instructorImg = gfx.image.new(configs.W_SCREEN, 16)
 
     gfx.lockFocus(instructorImg)
         gfx.drawText("press A to reset timer", 0, 0)

--- a/main.lua
+++ b/main.lua
@@ -3,7 +3,7 @@
 import "CoreLibs/object"
 import "CoreLibs/graphics"
 
-import "utils"
+import "utils"; --utils.disableReadOnly()
 import "configs"
 import "debugger"
 import "timer"
@@ -19,7 +19,6 @@ local instructorImg = nil; local instructorSprite = nil
 
 -- init() sets up our game environment.
 local function init()
-    --utils.disableReadOnly()
     --debugger.disable()
 
     workMinutes = 0.1

--- a/timer.lua
+++ b/timer.lua
@@ -16,13 +16,12 @@ local SEC_PER_MIN <const> = 60
 class('Timer').extends(gfx.sprite)
 
 -- TODO decide where I want to set timer posn; amend img size and init params accordingly
--- Timer:init(xpos, ypos, debugger) initializes, but does not start, a Timer.
-function Timer:init(x, y, debugger)
+-- Timer:init(xpos, ypos) initializes, but does not start, a Timer.
+function Timer:init(x, y)
     Timer.super.init(self)
 
     self:setCenter(0, 0)
     self:moveTo(x, y)
-    self.debugger = debugger
 
     self.timer = nil
     self.img = gfx.image.new(100, 50)
@@ -41,8 +40,8 @@ function Timer:update()
     if self.timer then
         local msec = self.timer.value
         local min, sec = convertTime(msec)
-        -- self.debugger:log("min: " .. min .. " sec: " .. sec)
-        -- self.debugger:log(self.timer.value)
+        -- debugger.log("min: " .. min .. " sec: " .. sec)
+        -- debugger.log(self.timer.value)
 
         local timeString = ""
         if min < 10 then timeString = "0" end
@@ -66,7 +65,7 @@ function Timer:update()
     end
 
     Timer.super.update(self)
-    self.debugger:bounds(self)
+    debugger.bounds(self)
 end
 
 function Timer:start(minsDuration)
@@ -75,13 +74,13 @@ function Timer:start(minsDuration)
         -- callback is a function closure that will be called when the timer is complete.
         -- TODO see playdate.timer.timerEndedCallback
         local msecDuration = minsDuration * SEC_PER_MIN * MSEC_PER_SEC
-        self.debugger:log(msecDuration)
+        debugger.log(msecDuration)
         self.timer = pd.timer.new(msecDuration, msecDuration, 0) -- "value-based" timer w linear interpolation
 
-        if self.timer then self.debugger:log("timer was nil - now created") end
+        if self.timer then debugger.log("timer was nil - now created") end
     else
         self.timer:start() -- TODO check that this autostarts the timer
-        self.debugger:log("timer not nil - started")
+        debugger.log("timer not nil - started")
     end
 end
 
@@ -95,7 +94,7 @@ end
 function Timer:reset()
     if self:timerIsNil("reset()") then return end
     self.timer:reset()
-    self.debugger:log("timer reset")
+    debugger.log("timer reset")
 end
 
 -- convertTime(msec) returns a (min, sec) conversion of the argument, rounded down
@@ -109,7 +108,7 @@ end
 -- TODO rm to optimize speed
 function Timer:timerIsNil(fName)
     if not self.timer then
-        self.debugger:log("self.timer is nil. Can't call " .. fName)
+        debugger.log("self.timer is nil. Can't call " .. fName)
         return true
     end
     return false

--- a/timer.lua
+++ b/timer.lua
@@ -14,6 +14,7 @@ class('Timer').extends(gfx.sprite)
 -- TODO decide where I want to set timer posn; amend img size and init params accordingly
 -- Timer:init(xpos, ypos) initializes, but does not start, a Timer.
 function Timer:init(x, y)
+    -- TODO give each timer a name
     Timer.super.init(self)
 
     self:setCenter(0, 0)
@@ -22,7 +23,7 @@ function Timer:init(x, y)
     self.timer = nil
     self.img = gfx.image.new(100, 50)
     self:setImage(self.img)
-    makeReadOnly(self, true, "timer instance")
+    self = utils.makeReadOnly(self, "timer instance")
 end
 
 --[[
@@ -112,5 +113,3 @@ function notify(t)
     -- call when countdown ends
 end
 --]]
-
-makeReadOnly(Timer, true)

--- a/timer.lua
+++ b/timer.lua
@@ -1,11 +1,5 @@
-import "CoreLibs/object"
-import "CoreLibs/graphics"
 import "CoreLibs/sprites"
 import "CoreLibs/timer"
-
-import "config"
-import "debugger"
-import "utils"
 
 local pd <const> = playdate
 local gfx <const> = pd.graphics

--- a/timer.lua
+++ b/timer.lua
@@ -1,0 +1,124 @@
+import "CoreLibs/object"
+import "CoreLibs/graphics"
+import "CoreLibs/sprites"
+import "CoreLibs/timer"
+
+import "config"
+import "debugger"
+
+local pd <const> = playdate
+local gfx <const> = pd.graphics
+
+local MSEC_PER_SEC <const> = 1000
+local SEC_PER_MIN <const> = 60
+
+-- Timer packs a timer with its UI
+class('Timer').extends(gfx.sprite)
+
+-- TODO decide where I want to set timer posn; amend img size and init params accordingly
+-- Timer:init(xpos, ypos, debugger) initializes, but does not start, a Timer.
+function Timer:init(x, y, debugger)
+    Timer.super.init(self)
+
+    self:setCenter(0, 0)
+    self:moveTo(x, y)
+    self.debugger = debugger
+
+    self.timer = nil
+    self.img = gfx.image.new(100, 50)
+    self:setImage(self.img)
+end
+
+--[[
+    :update() is called before :draw is called on all sprites
+    Suspected conditions for redrawing a sprite if getAlwaysRedraw() == false
+        - associated gfx.image has changed
+        - sprite has had some transform applied to it
+    So if we need to update a sprite every frame, do something in its :update()
+--]]
+-- Timer:update() draws the current time in the timer countdown
+function Timer:update()
+    if self.timer then
+        local msec = self.timer.value
+        local min, sec = convertTime(msec)
+        -- self.debugger:log("min: " .. min .. " sec: " .. sec)
+        -- self.debugger:log(self.timer.value)
+
+        local timeString = ""
+        if min < 10 then timeString = "0" end
+        timeString = timeString .. min .. ":"
+        if sec < 10 then timeString = timeString .. "0" end
+        timeString = timeString .. sec
+
+        gfx.lockFocus(self.img)
+            gfx.clear()
+            gfx.drawText(timeString, 0, 0)
+        gfx.unlockFocus()
+
+        -- if timer has completed
+        if msec <= 0 then
+            self.timer = nil
+            gfx.lockFocus(self.img)
+                gfx.clear()
+                gfx.drawText("DONE", 0, 0)
+            gfx.unlockFocus()
+        end
+    end
+
+    Timer.super.update(self)
+    self.debugger:bounds(self)
+end
+
+function Timer:start(minsDuration)
+    if not self.timer then -- TODO do  completed timers pass this? if not, test for playdate.timer.timeLeft instead
+        -- Returns a new playdate.timer that will run for duration milliseconds. 
+        -- callback is a function closure that will be called when the timer is complete.
+        -- TODO see playdate.timer.timerEndedCallback
+        local msecDuration = minsDuration * SEC_PER_MIN * MSEC_PER_SEC
+        self.debugger:log(msecDuration)
+        self.timer = pd.timer.new(msecDuration, msecDuration, 0) -- "value-based" timer w linear interpolation
+
+        if self.timer then self.debugger:log("timer was nil - now created") end
+    else
+        self.timer:start() -- TODO check that this autostarts the timer
+        self.debugger:log("timer not nil - started")
+    end
+end
+
+--[[ not needed yet
+function Timer:pause()
+    if self:timerIsNil("pause()") then return end
+    self.timer:pause()
+end
+--]]
+
+function Timer:reset()
+    if self:timerIsNil("reset()") then return end
+    self.timer:reset()
+    self.debugger:log("timer reset")
+end
+
+-- convertTime(msec) returns a (min, sec) conversion of the argument, rounded down
+function convertTime(msec)
+    local sec = msec / MSEC_PER_SEC
+    local min = math.floor(sec / SEC_PER_MIN)
+    sec = math.floor(sec - min * SEC_PER_MIN)
+    return min, sec
+end
+
+-- TODO rm to optimize speed
+function Timer:timerIsNil(fName)
+    if not self.timer then
+        self.debugger:log("self.timer is nil. Can't call " .. fName)
+        return true
+    end
+    return false
+end
+
+--[[ not needed yet
+-- this function may not need to be named here
+-- define it in the pd.timer.new closure?
+function notify(t)
+    -- call when countdown ends
+end
+--]]

--- a/utils.lua
+++ b/utils.lua
@@ -1,0 +1,52 @@
+-- pkgs decorators such as access control
+-- todo rename and move file into utils dir w debugger
+
+import "debugger"
+
+-- err() notifies of error
+--  msg         error message
+--  throwError  option to throw error, instead of log to debugger
+local function err(msg, throwError)
+    if throwError then error(msg)
+    else debugger.log(msg)
+    end
+end
+
+-- makeReadOnly() uses metamethods to prevent adding/reassigning keys
+--  t                   target table
+--  throwError          option to throw error upon write attempt, instead of log to debugger
+--  tname               table name
+--  SPECIAL EFFECTS     1. overwrites metatable's \_\_newindex
+--                      2. by default, 'classes' are permitted to have keys prefixed with "\_\_" overwritten (metamethods)
+--                          to disallow metamethod modification, manually provide a tname
+function makeReadOnly(t, throwError, tname)
+    local permitMetaMethods = false
+    
+    local mt = getmetatable(t)
+    if not mt then 
+        mt = {}
+        setmetatable(t, mt)
+    end
+
+    if not tname then 
+        if t.name then tname = t.name
+        elseif t.className then
+            tname = t.className
+            permitMetaMethods = true
+        else tname = "<unknown table name>" end
+    end
+    local msg = tname .. " read-only; forbidden to write to it directly. Rejected key: "
+    
+    if permitMetaMethods then
+        mt.__newindex = function(t,k,v)
+            -- permit adding/reassigning methods beginning w __
+            if k:sub(1,2) == "__" then rawset(t, k, v)
+            else err(msg .. k, throwError) end
+        end
+    else
+        mt.__newindex = function(t,k,v)
+            err(msg .. k, throwError)
+        end
+    end
+end
+

--- a/utils.lua
+++ b/utils.lua
@@ -1,50 +1,46 @@
 -- pkgs decorators such as access control
--- todo rename and move file into utils dir w debugger
 
--- err() notifies of error
---  msg         error message
---  throwError  option to throw error, instead of log to debugger
-local function err(msg, throwError)
-    if throwError then error(msg)
-    else debugger.log(msg)
-    end
+local enabled = true
+
+local function disableReadOnly()
+    enabled = false
 end
 
--- makeReadOnly() uses metamethods to prevent adding/reassigning keys
+-- makeReadOnly() uses metamethods to prevent adding new keys.
+-- Not true readonly, as k-v reassignment is unfortunately still permitted.
+-- Can use on tables such as class instances, but not on Playdate classes directly,
+--      due to Classes needing to be callable for Classname()-style instantiation.
 --  t                   target table
---  throwError          option to throw error upon write attempt, instead of log to debugger
 --  tname               table name
---  SPECIAL EFFECTS     1. overwrites metatable's \_\_newindex
---                      2. by default, 'classes' are permitted to have keys prefixed with "\_\_" overwritten (metamethods)
---                          to disallow metamethod modification, manually provide a tname
-function makeReadOnly(t, throwError, tname)
-    local permitMetaMethods = false
-    
-    local mt = getmetatable(t)
-    if not mt then 
-        mt = {}
-        setmetatable(t, mt)
+--  SPECIAL EFFECTS     1. overwrites metatable's \_\_index and \_\_newindex
+local function makeReadOnly(t0, tname, indexMetaBehaviour)
+    if not enabled then
+        return t0
     end
 
+    local proxy = {}
+    local mt = { __index = t0 }
+    setmetatable(proxy, mt)
+
     if not tname then 
-        if t.name then tname = t.name
-        elseif t.className then
-            tname = t.className
-            permitMetaMethods = true
+        if t0.name then tname = t0.name
+        elseif t0.className then
+            tname = t0.className
         else tname = "<unknown table name>" end
     end
     local msg = tname .. " read-only; forbidden to write to it directly. Rejected key: "
     
-    if permitMetaMethods then
-        mt.__newindex = function(t,k,v)
-            -- permit adding/reassigning methods beginning w __
-            if k:sub(1,2) == "__" then rawset(t, k, v)
-            else err(msg .. k, throwError) end
-        end
-    else
-        mt.__newindex = function(t,k,v)
-            err(msg .. k, throwError)
-        end
+    mt.__newindex = function(t,k,v)
+        error(msg .. k)
     end
+
+    return proxy
 end
 
+local exported = {
+    name = "utils",
+    disableReadOnly = disableReadOnly,
+    makeReadOnly = makeReadOnly
+}
+utils = makeReadOnly(exported)
+return utils

--- a/utils.lua
+++ b/utils.lua
@@ -1,8 +1,6 @@
 -- pkgs decorators such as access control
 -- todo rename and move file into utils dir w debugger
 
-import "debugger"
-
 -- err() notifies of error
 --  msg         error message
 --  throwError  option to throw error, instead of log to debugger


### PR DESCRIPTION
# Changelog
- Extracted timer, debugger, and config from main file
- Added ability to disable debugger
- Added pseudo-read-only tables. "Read-Only" tables can have values overwritten, but new keys cannot be added.

# Future work
- Attempt to reimplement packages as their own environments. [_ENV in Lua 5.2](http://underpop.online.fr/l/lua/faq/what-are-the-new-lua-5-2-features.htm)
- Optimize mem use with weak tables
- Optimize speed by setting more package lookups as local variables

## Tried and failed
- Making the global env read-only, due to the playdate SDK's liberal use of the global vars (perhaps more efficient?)