### PR TITLE
Adds configuration mode

### DIFF
--- a/app/configs.lua
+++ b/app/configs.lua
@@ -1,11 +1,5 @@
--- configs provides project-wide constants
--- todo probs should just have this export a bunch of namespace-unbound vars
-local P = {}; local _G = _G
-configs = {}
-
--- package contents and logic, within the package env --
-local _ENV = P
-name = "configs"
+-- configs provides project-wide constants,
+--      and it enables user configuration of some app functionality.
 
 W_SCREEN = 400
 W_CENTRE = 200
@@ -28,7 +22,9 @@ STATES = {
     DONE_TIMER  = 5
 }
 
--- prepare package for export, in the global env --
-local _ENV = _G
-configs = utils.makeReadOnly(P)
+configs = {
+    name = "configs",
+    
+}
+configs = utils.makeReadOnly(configs)
 return configs

--- a/app/configs.lua
+++ b/app/configs.lua
@@ -1,19 +1,18 @@
 -- configs provides project-wide constants,
 --      and it enables user configuration of some app functionality.
 
+-- The constant below are published straight to the importing environment,
+--      in this case, the global env.
 W_SCREEN = 400
 W_CENTRE = 200
 H_SCREEN = 240
 H_CENTRE = 120
 Z_MAX = 32767
 Z_MIN = -32768
-
 AXES = {
     X = 1,
     Y = 2
 }
-
--- todo rm??
 STATES = {
     LOADING     = 1,
     CONFIG      = 2,
@@ -22,9 +21,19 @@ STATES = {
     DONE_TIMER  = 5
 }
 
+local pd <const> = playdate
+
+local sysmenu = nil -- playdate system menu
+
+local function init()
+    sysmenu = pd.getSystemMenu()
+
+    sysmenu:addMenuItem("Reset poms", resetPomCount)
+end
+
 configs = {
     name = "configs",
-    
+    init = init
 }
 configs = utils.makeReadOnly(configs)
 return configs

--- a/app/confmanager.lua
+++ b/app/confmanager.lua
@@ -58,9 +58,7 @@ local function init()
     local pausingConf = List({"pausingConf", w_row, h_row}, list.orientations.horizontal)
     pausingConf:setEnablingCriteria(stateIsCONF)
     pausingConf:moveTo(20, 140)
-    local pausingText = pausingConf:addChildren(Textbox({"pausingText", w_text, h_row}), "Timer pausing enabled")[1]
-    --TODO addChildren should take an option to set the enabling criteria to depend on parent being enabled
-    pausingText:setEnablingCriteria(pausingConf:isEnabled())
+    local pausingText = pausingConf:addChildren(Textbox({"pausingText", w_text, h_row}, "Timer pausing enabled"), 'parentEnables')[1]
     w_setting = pausingConf:getMaxContentDim()
     local pausingToggle = List({"pausingToggle", w_setting, h_row}, list.orientations.horizontal)
     pausingToggle:setEnablingCriteria()

--- a/app/confmanager.lua
+++ b/app/confmanager.lua
@@ -47,6 +47,13 @@ local metaconfs = {
             d.log("no confs.pomsPerCycle.get func set")
             return confs.pomsPerCycle
         end
+    },
+    pomSavingOn = {
+        default = false,
+        get = function()
+            d.log("no confs.pomSavingOn.get func set")
+            return confs.pomSavingOn
+        end
     }
 }
 local snooze_max = 10
@@ -99,7 +106,7 @@ local function init(savestate)
     for _ in pairs(confs) do c_confs = c_confs + 1 end
     local w_setting, h_setting
     local w_label, h_label
-    local w_labelBonus = 50
+    local w_labelBonus = 80
     local w_setter, h_setter
 
     local confList = List(
@@ -184,6 +191,10 @@ local function init(savestate)
         metaconfs.pomsPerCycle.min,
         metaconfs.pomsPerCycle.max,
         confs.pomsPerCycle
+    )
+    metaconfs.pomSavingOn.get = fillONFSetter(
+        initConfItem("pomSavingOn", "Save elapsed poms on quit"),
+        confs.pomSavingOn
     )
 end
 

--- a/app/confmanager.lua
+++ b/app/confmanager.lua
@@ -1,7 +1,9 @@
--- configs provides project-wide constants,
+-- confmanager provides project-wide constants,
 --      and it enables user configuration of some app functionality.
 
--- The constant below are published straight to the importing environment,
+local pd <const> = playdate
+
+-- The constants below are published straight to the importing environment,
 --      in this case, the global env.
 W_SCREEN = 400
 W_CENTRE = 200
@@ -21,19 +23,18 @@ STATES = {
     DONE_TIMER  = 5
 }
 
-local pd <const> = playdate
-
 local sysmenu = nil -- playdate system menu
 
 local function init()
-    sysmenu = pd.getSystemMenu()
-
+    local sysmenu = pd.getSystemMenu()
     sysmenu:addMenuItem("Reset poms", resetPomCount)
+
+    
 end
 
-configs = {
-    name = "configs",
+confmanager = {
+    name = "confmanager",
     init = init
 }
-configs = utils.makeReadOnly(configs)
-return configs
+confmanager = utils.makeReadOnly(confmanager)
+return confmanager

--- a/app/confmanager.lua
+++ b/app/confmanager.lua
@@ -1,35 +1,19 @@
 -- confmanager provides project-wide constants,
 --      and it enables user configuration of some app functionality.
 
+import 'ui/list'
+import 'ui/textbox'
+
 local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local A <const> = pd.kButtonA
 local B <const> = pd.kButtonB
 
--- The constants below are published straight to the importing environment,
---      in this case, the global env.
-W_SCREEN = 400
-W_CENTRE = 200
-H_SCREEN = 240
-H_CENTRE = 120
-Z_MAX = 32767
-Z_MIN = -32768
-AXES = {
-    X = 1,
-    Y = 2
-}
-STATES = {
-    LOADING     = 1,
-    CONF        = 2,
-    MENU        = 3,
-    RUN_TIMER   = 4,
-    DONE_TIMER  = 5
-}
-
 local sysmenu = nil -- playdate system menu
 local confMenuItem = nil
 local backMenuItem = nil
+
 local enter = function() d.log("conf enter func not set") end
 local back = function() d.log("conf back func not set") end
 
@@ -60,9 +44,27 @@ local function init()
     backButton.isPressed = function() return pd.buttonJustPressed(B) end
     backButton.pressedAction = back
     backButton:forceConfigured()
-    local inst = Textbox({"backFromConfInst", 300, 30})
+    local inst = Textbox({"backFromConfInst", 300, 30}, "_B returns to app_")
     inst:setEnablingCriteria(stateIsCONF)
-    inst:setText("_B returns to app_", "dontResize")
+
+    --[[
+    local margin = 20
+    local w_row = 360
+    local w_text = 240
+    local w_setting = nil
+    local w_boolChoice = nil
+    local h_row = 30 --TODO rm; this should depend on config list height
+
+    local pausingConf = List({"pausingConf", w_row, h_row}, list.orientations.horizontal)
+    pausingConf:setEnablingCriteria(stateIsCONF)
+    pausingConf:moveTo(20, 140)
+    local pausingText = pausingConf:addChildren(Textbox({"pausingText", w_text, h_row}), "Timer pausing enabled")[1]
+    --TODO addChildren should take an option to set the enabling criteria to depend on parent being enabled
+    pausingText:setEnablingCriteria(pausingConf:isEnabled())
+    w_setting = pausingConf:getMaxContentDim()
+    local pausingToggle = List({"pausingToggle", w_setting, h_row}, list.orientations.horizontal)
+    pausingToggle:setEnablingCriteria()
+    --]]
 end
 
 confmanager = {

--- a/app/confmanager.lua
+++ b/app/confmanager.lua
@@ -2,6 +2,10 @@
 --      and it enables user configuration of some app functionality.
 
 local pd <const> = playdate
+local d <const> = debugger
+local gfx <const> = pd.graphics
+local A <const> = pd.kButtonA
+local B <const> = pd.kButtonB
 
 -- The constants below are published straight to the importing environment,
 --      in this case, the global env.
@@ -17,19 +21,48 @@ AXES = {
 }
 STATES = {
     LOADING     = 1,
-    CONFIG      = 2,
+    CONF        = 2,
     MENU        = 3,
     RUN_TIMER   = 4,
     DONE_TIMER  = 5
 }
 
 local sysmenu = nil -- playdate system menu
+local confMenuItem = nil
+local backMenuItem = nil
+local enter = function() d.log("conf enter func not set") end
+local back = function() d.log("conf back func not set") end
+
+function enter()
+    sysmenu:removeMenuItem(confMenuItem)
+    backMenuItem = sysmenu:addMenuItem("Back to app", back)
+    toConf()
+end
+
+function back()
+    sysmenu:removeMenuItem(backMenuItem)
+    confMenuItem = sysmenu:addMenuItem("Config", enter)
+    fromConf()
+end
 
 local function init()
-    local sysmenu = pd.getSystemMenu()
-    sysmenu:addMenuItem("Reset poms", resetPomCount)
+    local function stateIsCONF() return state == STATES.CONF end
 
-    
+    sysmenu = pd.getSystemMenu()
+    local resetPomsMenuItem = sysmenu:addMenuItem("Reset poms", resetPomCount)
+    -- The following 2 menu items will alternate
+    confMenuItem = sysmenu:addMenuItem("Config", enter)
+    backMenuItem = sysmenu:addMenuItem("Back to app", back)
+    sysmenu:removeMenuItem(backMenuItem)
+
+    local backButton = Button({"backFromConfButton"}, 'invisible')
+    backButton:setEnablingCriteria(stateIsCONF)
+    backButton.isPressed = function() return pd.buttonJustPressed(B) end
+    backButton.pressedAction = back
+    backButton:forceConfigured()
+    local inst = Textbox({"backFromConfInst", 300, 30})
+    inst:setEnablingCriteria(stateIsCONF)
+    inst:setText("_B returns to app_", "dontResize")
 end
 
 confmanager = {

--- a/app/confmanager.lua
+++ b/app/confmanager.lua
@@ -1,18 +1,32 @@
 -- confmanager provides project-wide constants,
 --      and it enables user configuration of some app functionality.
 
+--TODO standardize use of conf vs setting vocab
+
 import 'ui/list'
 import 'ui/textbox'
+import 'ui/button'
 
 local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local A <const> = pd.kButtonA
 local B <const> = pd.kButtonB
+local vert <const> = list.orientations.vertical
+local hori <const> = list.orientations.horizontal
+local pairs <const> = pairs
 
 local sysmenu = nil -- playdate system menu
 local confMenuItem = nil
 local backMenuItem = nil
+
+--- Published as the active set of confs
+local confs = {
+    snooze = nil
+}
+local defaults = {
+    snooze = true
+}
 
 local enter = function() d.log("conf enter func not set") end
 local back = function() d.log("conf back func not set") end
@@ -30,7 +44,14 @@ function back()
 end
 
 local function init()
+    local margin_screen = 20
     local function stateIsCONF() return state == STATES.CONF end
+
+    -- main will load and initialize any saved settings at startup
+    -- here, we init any outstanding non-initialized settings
+    for k, v in pairs(defaults) do
+        if confs[k] == nil then d.log("no conf " ..k) confs[k] = v end
+    end
 
     sysmenu = pd.getSystemMenu()
     local resetPomsMenuItem = sysmenu:addMenuItem("Reset poms", resetPomCount)
@@ -44,29 +65,72 @@ local function init()
     backButton.isPressed = function() return pd.buttonJustPressed(B) end
     backButton.pressedAction = back
     backButton:forceConfigured()
-    local inst = Textbox({"backFromConfInst", 300, 30}, "_B returns to app_")
-    inst:setEnablingCriteria(stateIsCONF)
+    local inst = Textbox({"backFromConfInst", 300, 20}, "_B returns to app_")
+    inst:setEnablingCriteria(function () return backButton:isEnabled() end)
+    inst:moveTo(margin_screen, H_SCREEN - margin_screen - inst.height) -- bottom of screen
 
-    --[[
-    local margin = 20
-    local w_row = 360
-    local w_text = 240
-    local w_setting = nil
-    local w_boolChoice = nil
-    local h_row = 30 --TODO rm; this should depend on config list height
+    local settings = {
+        snoozeONF = { -- the keys below will be present in all setting tables
+            item = nil, -- ui.list: the container to represent the setting in the confs table
+            desc = nil, -- ui.textbox: the setting description
+            setter = nil -- ui element: the interactable element
+        },
+        savePomCountONF = {},
+        pomsPerLongBreak = {},
+        snoozeDuration = {},
+        toWorkSound = {},
+        toBreakSound = {},
+        snoozeSound = {}
+    }
+    local c_settings = 0
+    for _ in pairs(settings) do c_settings = c_settings + 1 end
 
-    local pausingConf = List({"pausingConf", w_row, h_row}, list.orientations.horizontal)
-    pausingConf:setEnablingCriteria(stateIsCONF)
-    pausingConf:moveTo(20, 140)
-    local pausingText = pausingConf:addChildren(Textbox({"pausingText", w_text, h_row}, "Timer pausing enabled"), 'parentEnables')[1]
-    w_setting = pausingConf:getMaxContentDim()
-    local pausingToggle = List({"pausingToggle", w_setting, h_row}, list.orientations.horizontal)
-    pausingToggle:setEnablingCriteria()
-    --]]
+    local w_setting, h_setting
+    local w_desc, h_desc
+    local w_descBonus = 50
+    local w_setter, h_setter
+
+    local confList = List(
+        {"confList", W_SCREEN - margin_screen*2, inst.y - 10 - margin_screen},
+        vert, 2
+    )
+    confList:moveTo(margin_screen, margin_screen)
+    w_setting, h_setting = confList:getMaxContentDim(c_settings)
+    confList:setEnablingCriteria(stateIsCONF)
+
+    --TODO this block should be generic to all settings
+    settings.snoozeONF.item = List({"snoozeONF", w_setting, h_setting}, hori, 0)
+    w_setter, h_setter = settings.snoozeONF.item:getMaxContentDim(2)
+    h_desc = h_setter
+    w_desc = w_setter + w_descBonus -- give desc a bit more room
+    w_setter = w_setter - w_descBonus
+    settings.snoozeONF.desc = Textbox({"snoozeONFDesc", w_desc, h_desc},
+        "Timer snoozing")
+    settings.snoozeONF.desc.isSelected = function() return false end
+    settings.snoozeONF.setter = List({"snoozeONFSetter", w_setter, h_setter}, hori, 0)
+    local item = settings.snoozeONF.item --TODO refactor once generic
+    settings.snoozeONF.setter.isSelected = function() return item.isSelected() end
+    settings.snoozeONF.item:addChildren(
+        {settings.snoozeONF.desc, settings.snoozeONF.setter}, 'parentEnables')
+    confList:addChildren(settings.snoozeONF.item, 'parentEnables')
+    settings.snoozeONF.setter.isSelected = function() return item.isSelected() end
+
+    local w_tmp, h_tmp = settings.snoozeONF.setter:getMaxContentDim(2)
+    local snoozeOnBtn = Button({"snoozeOnButton", w_tmp, h_tmp})
+    snoozeOnBtn:setLabel("On")
+    snoozeOnBtn.isPressed = function() return snoozeOnBtn.isSelected() end
+    snoozeOnBtn.pressedAction = function() confs.snooze = true end
+    local snoozeOffBtn = Button({"snoozeOffButton", w_tmp, h_tmp})
+    snoozeOffBtn:setLabel("Off")
+    snoozeOffBtn.isPressed = function() return snoozeOffBtn.isSelected() end
+    snoozeOffBtn.pressedAction = function() confs.snooze = false end
+    settings.snoozeONF.setter:addChildren({snoozeOnBtn, snoozeOffBtn}, 'parentEnables')
+    if not confs.snooze then settings.snoozeONF.setter:next() end -- toggle to loaded setting val
 end
 
 confmanager = {
     name = "confmanager",
+    confs = confs,
     init = init
 }
 confmanager = utils.makeReadOnly(confmanager)

--- a/app/gconsts.lua
+++ b/app/gconsts.lua
@@ -1,0 +1,15 @@
+-- The constants below are published straight to the importing environment,
+--      in this case, the global env.
+W_SCREEN = 400
+W_CENTRE = 200
+H_SCREEN = 240
+H_CENTRE = 120
+Z_MAX = 32767
+Z_MIN = -32768
+STATES = {
+    LOADING     = 1,
+    CONF        = 2,
+    MENU        = 3,
+    RUN_TIMER   = 4,
+    DONE_TIMER  = 5
+}

--- a/app/main.lua
+++ b/app/main.lua
@@ -182,22 +182,14 @@ end
 -- TODO align semantics of menu w pause
 -- TODO rename to toMENU
 function toMenu()
-    if timerCompleted then
-        if currentTimer == timers.long then
-            c_poms = 0
-        elseif currentTimer == timers.work then
-            c_poms = c_poms + 1
-        end
-        if c_poms >= confs.pomsPerCycle then
-            --TODO alert user that the cycle pom count has been reached
-        end
-        cycleTimers()
-    end
-    timerCompleted = false
-
     currentTimer:remove()
     c_pauses = 0
     c_snoozes = 0
+
+    cycleTimers()
+    if c_poms >= confs.pomsPerCycle then
+        --TODO alert user that the cycle pom count has been reached
+    end
 
     pd.setAutoLockDisabled(false) --TODO verify this is still needed
     state = STATES.MENU
@@ -218,7 +210,13 @@ end
 function toDone()
     currentTimer:stop()
     currentTimer:notify()
-    timerCompleted = true
+    
+    if currentTimer == timers.long then
+        c_poms = 0
+    elseif currentTimer == timers.work then
+        c_poms = c_poms + 1
+    end
+
     state = STATES.DONE_TIMER
 end
 

--- a/app/main.lua
+++ b/app/main.lua
@@ -22,17 +22,14 @@ local A <const> = pd.kButtonA
 local B <const> = pd.kButtonB
 
 -- TODO can states be a set of update funcs, or do we need the enum?
-STATES = configs.STATES
 state = STATES.LOADING
-
-AXES = configs.AXES
-
 initialDurations = {
     work = 25,
     short = 5,
     long = 20,
     snooze = 2
 }
+
 local splashSprite = nil
 local timers = {
     work = 'nil',
@@ -94,8 +91,7 @@ end
 
 --TODO replace with a launchImage, configurable in pdxinfo
 local function splash()
-    -- TODO maybe the configs really should just be globals in main. or in configs.lua w/o namespacing
-    local splashImg = gfx.image.new(configs.W_SCREEN, configs.H_SCREEN)
+    local splashImg = gfx.image.new(W_SCREEN, H_SCREEN)
     gfx.pushContext(splashImg)
         gfx.drawText("*POMDATE*", 50, 90)
         gfx.drawText("press A to continue", 50, 140)

--- a/app/main.lua
+++ b/app/main.lua
@@ -12,6 +12,7 @@ import "CoreLibs/ui"
 import "gconsts"
 import "utils/utils";
 import "utils/debugger"
+import "utils/crankhandler"
 import "timer"
 import "confmanager"
 import "uimanager"
@@ -186,7 +187,6 @@ function toMenu()
     c_snoozes = 0
 
     pd.setAutoLockDisabled(false) --TODO verify this is still needed
-    pd.getCrankTicks(1) --TODO move this crank-data-dump to uimanager file
     state = STATES.MENU
 end
 
@@ -264,6 +264,7 @@ function pd.update()
     end
 
     uimanager.update()
+    crankhandler.update()
     pd.timer.updateTimers()
     gfx.sprite.update()
 end

--- a/app/main.lua
+++ b/app/main.lua
@@ -10,7 +10,7 @@ import "CoreLibs/sprites"
 import "CoreLibs/ui"
 
 import "utils/utils";
-import "configs"
+import "confmanager"
 import "utils/debugger"
 import "timer"
 import "uimanager"
@@ -59,7 +59,7 @@ local function init()
     --utils.disableReadOnly()
     --debugger.disable()
 
-    configs.init()
+    confmanager.init()
 
     d.log("attempting to loadState")
     local loadedState = pd.datastore.read("durations")

--- a/app/main.lua
+++ b/app/main.lua
@@ -79,6 +79,13 @@ local function init()
 
     confmanager.init(sav_confs)
 
+    if confs.pomSavingOn then
+        d.log("attempting to load state: data")
+        c_poms = pd.datastore.read("data")["c_poms"]
+        d.log("conf-loading attempt complete; c_poms:", c_poms)
+        if not c_poms then c_poms = 0 end
+    end
+
     timers.work = Timer("work")
     timers.short = Timer("short")
     timers.long = Timer("long")
@@ -125,13 +132,18 @@ local function sav()
     } -- snooze duration is in the confs data file
     d.log("dumping durations to be saved", sav_durations)
     pd.datastore.write(sav_durations, "durations")
-    d.log("duration save attempt complete. Dumping datastore contents", pd.datastore.read("durations"))
+    d.log("duration save attempt complete. Dumping datafile", pd.datastore.read("durations"))
 
-    -- Seems we may want to let confmanager handle its own state saving
     local sav_confs = confmanager.sav()
     d.log("dumping confs to be saved", sav_confs)
     pd.datastore.write(sav_confs, "confs")
-    d.log("conf save attempt complete. Dumping datastore contents", pd.datastore.read("confs"))
+    d.log("conf save attempt complete. Dumping datafile", pd.datastore.read("confs"))
+
+    if confs.pomSavingOn then
+        d.log("Elapsed poms to be saved: ", c_poms)
+        pd.datastore.write({ c_poms = c_poms }, "data")
+        d.log("Elapsed poms save attempt complete. Dumping datafile", pd.datastore.read("data"))
+    end
 end
 
 local function cycleTimers()

--- a/app/main.lua
+++ b/app/main.lua
@@ -9,6 +9,7 @@ import "CoreLibs/graphics"
 import "CoreLibs/sprites"
 import "CoreLibs/ui"
 
+import "gconsts"
 import "utils/utils";
 import "confmanager"
 import "utils/debugger"

--- a/app/main.lua
+++ b/app/main.lua
@@ -43,6 +43,7 @@ local timerCompleted = false
 local c_poms = 0
 local c_pauses = 0
 local c_snoozes = 0
+local cachedState = nil -- state prior to entering configuration mode
 
 local snoozeMins = 2 --TODO make configurable
 local n_poms = 4 --TODO make configurable
@@ -139,6 +140,20 @@ local function cycleTimers()
     end
 end
 
+function toConf()
+    pause()
+    currentTimer:setVisible(false)
+    cachedState = state
+    state = STATES.CONF
+end
+
+function fromConf()
+    unpause()
+    currentTimer:setVisible(true)
+    state = cachedState
+    cachedState = nil
+end
+
 -- performs done -> select transition
 -- then inits select
 -- then switches update func
@@ -163,7 +178,7 @@ function toMenu()
     c_pauses = 0
     c_snoozes = 0
 
-    pd.setAutoLockDisabled(false)
+    pd.setAutoLockDisabled(false) --TODO verify this is still needed
     pd.getCrankTicks(1) --TODO move this crank-data-dump to uimanager file
     state = STATES.MENU
 end

--- a/app/main.lua
+++ b/app/main.lua
@@ -30,8 +30,7 @@ confs = confmanager.confs
 initialDurations = {
     work = 25,
     short = 5,
-    long = 20,
-    snooze = 2
+    long = 20
 }
 
 local splashSprite = nil
@@ -49,7 +48,6 @@ local c_pauses = 0
 local c_snoozes = 0
 local cachedState = nil -- state prior to entering configuration mode
 
-local snoozeMins = 2 --TODO make configurable
 local n_poms = 4 --TODO make configurable
 
 --TODO move below asset path info to config or smth
@@ -64,6 +62,7 @@ local function init()
     utils.disableReadOnly()
     --debugger.disable()
 
+    -- snooze duration is in the confs data file
     d.log("attempting to load state: durations")
     local loadedDurations = pd.datastore.read("durations")
     if loadedDurations then
@@ -124,7 +123,7 @@ local function saveState()
         work = uimanager.getDialValue("work"),
         short = uimanager.getDialValue("short"),
         long = uimanager.getDialValue("long")
-    }
+    } -- snooze duration is in the confs data file
     d.log("dumping durations to be saved", durations)
     pd.datastore.write(durations, "durations")
     d.log("duration save attempt complete. Dumping datastore contents", pd.datastore.read("durations"))
@@ -217,7 +216,7 @@ function snooze()
     --else
         c_snoozes = c_snoozes + 1
         currentTimer:remove()
-        toRun(timers.snooze, snoozeMins)
+        toRun(timers.snooze, confs.snoozeDuration)
     --end
 end
 

--- a/app/main.lua
+++ b/app/main.lua
@@ -58,6 +58,9 @@ local snoozeSoundPath = "snooze.wav"
 local function init()
     --utils.disableReadOnly()
     --debugger.disable()
+
+    configs.init()
+
     d.log("attempting to loadState")
     local loadedState = pd.datastore.read("durations")
     if loadedState then
@@ -215,20 +218,17 @@ end
 
 --- Get the number of times the current timer has been paused
 ---@return integer
-function getPauseCount()
-    return c_pauses
-end
+function getPauseCount() return c_pauses end
 
 --- Get the number of times the current timer has been snoozed
 ---@return integer
-function getSnoozeCount()
-    return c_snoozes
-end
+function getSnoozeCount() return c_snoozes end
 
 --- Get the number of completed pomodoros
-function getPomCount()
-    return c_poms
-end
+function getPomCount() return c_poms end
+
+--- Reset the pom cycle by resetting the completed-pomodoro count
+function resetPomCount() c_poms = 0 end
 
 -- pd.update() is called right before every frame is drawn onscreen.
 function pd.update()

--- a/app/main.lua
+++ b/app/main.lua
@@ -48,8 +48,6 @@ local c_pauses = 0
 local c_snoozes = 0
 local cachedState = nil -- state prior to entering configuration mode
 
-local n_poms = 4 --TODO make configurable
-
 --TODO move below asset path info to config or smth
 local soundPathPrefix = "assets/sound/"
 local toWorkSoundPath = "to-work.wav"
@@ -142,7 +140,7 @@ local function cycleTimers()
     elseif currentTimer == timers.long then
         uimanager.selectPrevTimer()
     elseif currentTimer == timers.work then
-        if c_poms >= n_poms then
+        if c_poms >= confs.pomsPerCycle then
             uimanager.selectNextTimer()
         else
             uimanager.selectPrevTimer()
@@ -178,7 +176,7 @@ function toMenu()
         elseif currentTimer == timers.work then
             c_poms = c_poms + 1
         end
-        if c_poms >= n_poms then
+        if c_poms >= confs.pomsPerCycle then
             --TODO alert user that the cycle pom count has been reached
         end
         cycleTimers()

--- a/app/timer.lua
+++ b/app/timer.lua
@@ -11,7 +11,7 @@ local d <const> = debugger
 local gfx <const> = pd.graphics
 local utils <const> = utils
 local floor <const> = math.floor -- TODO may be able to replace this w // floor division lua operator?
-local STATES <const> = configs.STATES
+local STATES <const> = STATES
 
 -- Timer packs a timer with its UI.
 class('Timer').extends(gfx.sprite)

--- a/app/ui/dial.lua
+++ b/app/ui/dial.lua
@@ -11,7 +11,6 @@ local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local utils <const> = utils
-local configs <const> = configs
 local d <const> = debugger
 --local externalfunc <const> = somepkg.func --TODO any other external vars go here
 

--- a/app/ui/dial.lua
+++ b/app/ui/dial.lua
@@ -31,11 +31,11 @@ visualizers = {
 ---         'name' or 1: (string) button name for debugging
 ---         'w' or 2: (integer; optional) initial width, defaults to screen width
 ---         'h' or 3: (integer; optional) initial height, defaults to screen height
----@param step integer step to inc/decrement the value on the dial by
 ---@param lowerLimit integer (optional) cease dialing back past this value
 ---@param upperLimit integer (optional) cease dialing forward past this value
----@param initalVal integer (optional) initial value
-function Dial:init(coreProps, step, lowerLimit, upperLimit, initialVal)
+---@param step integer (optional) step to inc/decrement the value on the dial by. Defaults to 1
+function Dial:init(coreProps, lowerLimit, upperLimit, step)
+    if not step then step = 1 end
     Dial.super.init(self, coreProps) --should always be at top of init func
 
     self._spacing = 2
@@ -56,8 +56,7 @@ function Dial:init(coreProps, step, lowerLimit, upperLimit, initialVal)
         self._uppLimit = upperLimit
         self.value = upperLimit
     end
-    if initialVal then self:setValue(initialVal)
-    elseif not self.value then self:setValue(0) end
+    if not self.value then self:setValue(0) end
 
     self._unit = "unit"
     self._counter = gfx.image.new(20, 20)

--- a/app/ui/list.lua
+++ b/app/ui/list.lua
@@ -14,7 +14,7 @@ local ipairs <const> = ipairs
 local abs <const> = math.abs
 local type <const> = type
 
-local AXES <const> = configs.AXES
+local AXES <const> = AXES
 local UP <const> = pd.kButtonUp
 local DOWN <const> = pd.kButtonDown
 local LEFT <const> = pd.kButtonLeft

--- a/app/ui/list.lua
+++ b/app/ui/list.lua
@@ -116,8 +116,9 @@ end
 --- No option to keep child's global posn,
 ---     since the list *must* control child layout.
 ---@param e table of child UIElements, or a single UIElement
-function List:addChildren(e)
-    local newChildren = List.super.addChildren(self, e)
+---@param parentEnables boolean (option) child is enabled/disabled when parent is enabled/disabled
+function List:addChildren(e, parentEnables)
+    local newChildren = List.super.addChildren(self, e, parentEnables)
     --d.log("adding child " .. e.name)
     
     for _, child in ipairs(newChildren) do

--- a/app/ui/list.lua
+++ b/app/ui/list.lua
@@ -30,27 +30,31 @@ local List <const> = List
 local _ENV = P
 name = "list"
 
---TODO instead of AXES enum, use list.orientations.horizontal and list.orientations.vertical enum, like the modes in dial
+orientations = {
+    horizontal = 1,
+    vertical = 2
+}
+
 --      bug in current app is caused by the text not fitting in the list
 --- Initializes a list UIElement.
 ---@param coreProps table containing the following core properties, named or array-indexed:
 ---         'name' or 1: (string) button name for debugging
 ---         'w' or 2: (integer; optional) initial width, defaults to screen width
 ---         'h' or 3: (integer; optional) initial height, defaults to screen height
----@param axis enum (optional) member of AXES enum; determines list axis (X: hori, Y: vert). Defaults to vert.
+---@param orientiation enum (optional) member of list.ol. Defaults to vert.
 ---@param spacing integer (optional) number of pixels between UIElements (this list & its children)
-function List:init(coreProps, axis, spacing)
+function List:init(coreProps, orientiation, spacing)
     if not spacing or type(spacing) ~= 'number' then spacing = 0 end
     List.super.init(self, coreProps)
 
     self._spacing = spacing
-    self._axis = axis
+    self._orientation = orientiation
     self._lastChild = nil -- latest child added to list
 
-    -- axis-based layouts
-    -- could be split into axis-specific subclasses,
+    -- orientation-based orientations
+    -- could be split into orientation-specific subclasses,
     --      but atm I don't want to spare the extra __index lookup
-    if self._axis == AXES.X then
+    if self._orientation == orientations.horizontal then
         self._inputPrev = LEFT
         self._inputNext = RIGHT
 
@@ -71,7 +75,7 @@ function List:init(coreProps, axis, spacing)
             return x, y
         end
     else -- default to vertical layout
-        self._axis = AXES.Y -- default vert orientation
+        self._orientation = orientations.vertical
         self._inputPrev = UP
         self._inputNext = DOWN
 
@@ -146,7 +150,7 @@ function List:getMaxContentDim(nNewElements)
         nNewElements = 1
     end
 
-    local axis = self._axis
+    local orientation = self._orientation
     local spacing = self._spacing
     local lastChild = self._lastChild
 
@@ -155,12 +159,15 @@ function List:getMaxContentDim(nNewElements)
     local function spaceAfterChildren()
 
         local measure = nil
-        if axis == AXES.X then
+        local axis = nil
+        if orientation == orientations.horizontal then
             measure = "width"
-        elseif axis == AXES.Y then
+            axis = "x"
+        elseif orientation == orientations.vertical then
             measure = "height"
+            axis = "y"
         else
-            d.log("can't position along '" .. axis .. "' dimension")
+            d.log("can't position along '" .. orientation .. "' dimension")
             return 0
         end
 
@@ -178,7 +185,7 @@ function List:getMaxContentDim(nNewElements)
     if leftover ~= 0 then d.log(leftover .. " pix will be left over within " .. self.name .. " list") end
 
     local w = 0 ; local h = 0
-    if self.axis == AXES.X then
+    if orientation == orientations.horizontal then
         w = available // nNewElements
         h = self.height - 2 * spacing
     else

--- a/app/ui/switch.lua
+++ b/app/ui/switch.lua
@@ -11,7 +11,6 @@ local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local utils <const> = utils
-local configs <const> = configs
 local d <const> = debugger
 local insert <const> = table.insert
 local Object <const> = Object

--- a/app/ui/textbox.lua
+++ b/app/ui/textbox.lua
@@ -31,11 +31,13 @@ name = "textbox"
 ---         'name' or 1: (string) button name for debugging
 ---         'w' or 2: (integer; optional) initial width, defaults to screen width
 ---         'h' or 3: (integer; optional) initial height, defaults to screen height
-function Textbox:init(coreProps)
+---@param text string (optional) text to set
+function Textbox:init(coreProps, text)
     Textbox.super.init(self, coreProps) --should always be at top of init func
 
     self._font = gfx.getFont() --TODO make font config'able
-    self:setText(self.name .. " no text set", 'dontResize')
+    if text then self:setText(text)
+    else self:setText(self.name .. " notext") end
 
     self = utils.makeReadOnly(self, "Textbox instance")
 end
@@ -54,28 +56,15 @@ function Textbox:setFont(font)
     self._font = font
 end
 
---TODO word wrapping
+--TODO word wrapping, resizing
 --- Set the label to show on the button
 ---@param text string
----@param dontResize boolean (optional) see resize(). Resizes unless this flag is set.
-function Textbox:setText(text, dontResize)
+function Textbox:setText(text)
     gfx.pushContext(self._img)
         --TODO set font to self._font prior to printing text
         gfx.clear()
-        gfx.drawText(text, 2, 2) -- TODO refactor
+        gfx.drawText(text, 0, 0)
     gfx.popContext()
-    if not dontResize then self:resize() end
-end
-
---TODO just a func skeleton; make this actually work
---- Trim the textbox sprite size to the minimum required
----     for the text it contains.
---- Min textbox size is 1x1 pixels.
---- Max textbox size is always the screen dimensions.
----@return integer new width
----@return integer new height
-function Textbox:resize()
-    return self._img:getSize()
 end
 
 -- pkg footer: pack and export the namespace.

--- a/app/ui/textbox.lua
+++ b/app/ui/textbox.lua
@@ -11,7 +11,6 @@ local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local utils <const> = utils
-local configs <const> = configs
 local d <const> = debugger
 --local externalfunc <const> = somepkg.func --TODO any other external vars go here
 

--- a/app/ui/uielement.lua
+++ b/app/ui/uielement.lua
@@ -165,9 +165,6 @@ function UIElement:addChildren(e, parentEnables)
 
     if e.isa then addChild(e)
     else
-        for _, element in ipairs(e) do
-            addChild(element)
-        end
         for _, element in pairs(e) do
             addChild(element)
         end

--- a/app/ui/uielement.lua
+++ b/app/ui/uielement.lua
@@ -134,10 +134,10 @@ end
 
 --- Parents another UIElement.
 ---@param e table of child UIElements, or a single UIElement
----@param keepGlobalPos boolean (option) keep the children's global position as is
+---@param parentEnables boolean (option) child is enabled/disabled when parent is enabled/disabled
 ---@return table of successfully added child UIElements
 ---SPEC EFFECT  overrides each child's ZIndex to be relative to parent above its new parent
-function UIElement:addChildren(e, keepGlobalPos)
+function UIElement:addChildren(e, parentEnables)
     --TODO want to check e:isa(UIElement) but isa seems to be unstable in 1.12.3?
     if not (e and type(e) == 'table') then
         d.log("no children to add to " .. self.name)
@@ -156,9 +156,10 @@ function UIElement:addChildren(e, keepGlobalPos)
         element._parent = self
         insert(self._children, element)
         insert(newChildren, element)
-        if not keepGlobalPos then
-            element:moveTo(self.x + element.x, self.y + element.y)
+        if parentEnables then
+            element:setEnablingCriteria(function() return self:isEnabled() end)
         end
+        element:moveTo(self.x + element.x, self.y + element.y)
         element:setZIndex(element:getZIndex() + self:getZIndex())    
     end
 

--- a/app/ui/uielement.lua
+++ b/app/ui/uielement.lua
@@ -13,13 +13,15 @@ local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local utils <const> = utils
-local configs <const> = configs
 local d <const> = debugger
-local Switch = Switch
-local type = type
+local Switch <const> = Switch
+local type <const> = type
 local pairs <const> = pairs
 local ipairs <const> = ipairs
 local insert <const> = table.insert
+
+local W_SCREEN <const> = W_SCREEN
+local H_SCREEN <const> = H_SCREEN
 
 --- UIElement is an interactive sprite that can parent other UIElements.
 --- It can be an abstract class for more specialized UI components, or
@@ -59,10 +61,10 @@ function UIElement:init(coreProps)
         name = "unnamed-UIElement"
     end
     if not w or w == 0 or type(w) ~= 'number' then
-        w = configs.W_SCREEN
+        w = W_SCREEN
     end
     if not h or h == 0 or type(h) ~= 'number' then
-        h = configs.H_SCREEN
+        h = H_SCREEN
     end
     w = w // 1 -- ensure int
     h = h // 1

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -210,11 +210,11 @@ local function init(timers)
     scoreboard:moveTo(300, 60)
     scoreboard:setZIndex(80)
 
-    pomCountDisplay = List({"pomCountDisplay", 100, 40})
+    pomCountDisplay = List({"pomCountDisplay", 100, 25})
     pomCountDisplay:setEnablingCriteria(function() return state == STATES.MENU end)
     makeScoreDisplays(pomCountDisplay, { pom = getPomCount })
         [1]:setMode(dial.visualizers.horiCounter) -- visualize poms as counters
-    pomCountDisplay:moveTo(20, 200)
+    pomCountDisplay:moveTo(20, 20)
     pomCountDisplay:setZIndex(80)
 
     --- Populate a list containing instructions for the user.
@@ -236,11 +236,12 @@ local function init(timers)
         end
     end
 
-    menuInst = List({"menuInstList", 200, 60})
+    menuInst = List({"menuInstList", 230, 90})
     menuInst:setEnablingCriteria(function() return state == STATES.MENU end)
     writeInstructions(menuInst, {
         runTimer = "A starts selected timer", --TODO DEBUG not appearing onscreen
-        setTimer = "Held B + Crank sets duration"
+        setTimer = "Held B + Crank sets duration",
+        configApp = "System menu has config options"
     })
     menuInst:moveTo(20, 140)
     menuInst:setZIndex(60)

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -82,9 +82,8 @@ local function init(timers)
                 and button.isSelected()
             end)
             dial.isSelected = function () return pd.buttonIsPressed(B) end
-            local ticks = 60 / CRANK_ROTS_PER_HOUR
             dial.getDialChange = function ()
-                return crankhandler.getCrankTicks(ticks)
+                return crankhandler.getCrankTicks(60 / CRANK_ROTS_PER_HOUR)
             end
             dial:setUnit("min")
             dial:setValue(initialDurations[name])

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -241,7 +241,7 @@ local function init(timers)
     writeInstructions(menuInst, {
         runTimer = "A starts selected timer", --TODO DEBUG not appearing onscreen
         setTimer = "Held B + Crank sets duration",
-        configApp = "System menu has config options"
+        confApp = "System menu has config options"
     })
     menuInst:moveTo(20, 140)
     menuInst:setZIndex(60)

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -229,9 +229,8 @@ local function init(timers)
         local w, h = list:getMaxContentDim(n)
 
         for name, text in pairs(instructions) do
-            local inst = Textbox({name .. "Inst", w, h})
+            local inst = Textbox({name .. "Inst", w, h}, "_"..text.."_")
             inst:setEnablingCriteria(function() return list:isEnabled() end)
-            inst:setText("_"..text.."_", "dontResize")
             list:addChildren(inst)
         end
     end

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -71,7 +71,6 @@ local function init(timers)
 
             local button = Button({name .. "Button", wButton, hButton})
             timerSelectButtons[name] = button
-            button:setEnablingCriteria(function() return list:isEnabled() end)
             button.isPressed = function() return pd.buttonJustPressed(A) end
             button:setLabel(label)
 
@@ -98,7 +97,7 @@ local function init(timers)
         end
 
         for _, timer in pairs(timers) do
-            list:addChildren(makeTimerSelector(timer.t, timer.label))
+            list:addChildren(makeTimerSelector(timer.t, timer.label), 'parentEnables')
         end
     end
 
@@ -230,8 +229,7 @@ local function init(timers)
 
         for name, text in pairs(instructions) do
             local inst = Textbox({name .. "Inst", w, h}, "_"..text.."_")
-            inst:setEnablingCriteria(function() return list:isEnabled() end)
-            list:addChildren(inst)
+            list:addChildren(inst, 'parentEnables')
         end
     end
 

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -156,7 +156,7 @@ local function init(timers)
     snoozeButton = Button({"snoozeButton"}, 'invisible')
     snoozeButton:setEnablingCriteria(function()
         return state == STATES.DONE_TIMER
-        and confs.snooze
+        and confs.snoozeOn
     end)
     snoozeButton.isPressed = function() return pd.buttonJustPressed(A) end
     snoozeButton.pressedAction = function()
@@ -268,7 +268,7 @@ local function init(timers)
         toMenu = "B returns to menu"
     })
     .snooze:setEnablingCriteria(function() return
-        confs.snooze
+        confs.snoozeOn
         and doneTimerInst:isEnabled() 
     end)
     doneTimerInst:moveTo(20, 140)

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -56,13 +56,13 @@ local scoreboard = nil -- visualizes pause and snooze scores for this timer sess
 ---                 in {t, label} k-v tuples,
 ---                 in the sequence they should appear.
 local function init(timers)
-    --- Add all of the timer-selecting/-configuring UIElements that are
-    ---     displayed on the MENU screen.
+    --- Populate timersMenu with the timer-selecting/-configuring UIElements that are
+    ---     to be displayed on the MENU screen.
     ---@param list List to contain the timer-selecting buttons
     ---@param timers table all Timers to make selectors for,
     ---                 in {t, label} k-v tuples,
     ---                 in the sequence they should appear.
-    local function populateTimersMenu (list, timers)
+    local function fillTimersMenu (list, timers)
         local n = 0
         n = #timers
         local wButton, hButton = list:getMaxContentDim(n)
@@ -75,7 +75,7 @@ local function init(timers)
             button.isPressed = function() return pd.buttonJustPressed(A) end
             button:setLabel(label)
 
-            local dial = Dial({name .. "Dial", 80, 40}, 1, 1, 60)
+            local dial = Dial({name .. "Dial", 80, 40}, 1, 60)
             durationDials[name] = dial
             dial:setEnablingCriteria(function() return
                 button:isEnabled()
@@ -106,10 +106,10 @@ local function init(timers)
     timersMenu:setEnablingCriteria(function () return state == STATES.MENU end)
     -- TODO when configmenu + menuList, remove the following line
     timersMenu.isSelected = function() return state == STATES.MENU end
-    populateTimersMenu(timersMenu, timers)
+    fillTimersMenu(timersMenu, timers)
     timersMenu:moveTo(250, 60)
 
-    --TODO mv to populateTimersMenu
+    --TODO mv to fillTimersMenu
     for _, dial in pairs(durationDials) do
         dial:moveTo(20, 60)
     end
@@ -179,7 +179,7 @@ local function init(timers)
 
         local created = {}
         for unit, score in pairs(scoringFuncs) do
-            local display = Dial({unit .. "Score", w, h}, 1)
+            local display = Dial({unit .. "Score", w, h})
             list:addChildren(display)
             display:setEnablingCriteria(function() return
                 list:isEnabled() 

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -291,7 +291,7 @@ local function selectNextTimer()
 end
 
 uimanager = {
-    name = "manage_ui",
+    name = "uimanager",
     init = init,
     update = update,
     getDialValue = getDialValue,

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -26,6 +26,7 @@ local A <const> = pd.kButtonA
 local B <const> = pd.kButtonB
 local pairs <const> = pairs
 local ipairs <const> = ipairs
+local crankhandler <const> = crankhandler
 
 local CRANK_ROTS_PER_HOUR <const> = 3 -- tune timer-setting dial sensitivity
 
@@ -83,9 +84,7 @@ local function init(timers)
             dial.isSelected = function () return pd.buttonIsPressed(B) end
             local ticks = 60 / CRANK_ROTS_PER_HOUR
             dial.getDialChange = function ()
-                --TODO BUG dial crank ticks continue getting counted while B
-                --  is not held down
-                return pd.getCrankTicks(ticks)
+                return crankhandler.getCrankTicks(ticks)
             end
             dial:setUnit("min")
             dial:setValue(initialDurations[name])
@@ -243,6 +242,7 @@ local function init(timers)
         return created
     end
 
+    --TODO DEBUG only 2/3 (or 1/2) instructions showing up per state
     menuInst = List({"menuInstList", 230, 90})
     menuInst:setEnablingCriteria(function() return state == STATES.MENU end)
     writeInstructions(menuInst, {

--- a/app/utils/crankhandler.lua
+++ b/app/utils/crankhandler.lua
@@ -1,0 +1,29 @@
+--- Dumps crank change data every frame that the crank is not in use.
+--- Must call update() to drive.
+
+local pd <const> = playdate
+local d <const> = debugger
+
+local usingcrank = false
+
+--- Get the number of ticks that the crank has turned through
+---     since the previous frame.
+---@param ticksPerRevolution int frequency of ticks per full revolution of the crank
+local function getCrankTicks(ticksPerRevolution)
+    usingcrank = true
+    return pd.getCrankTicks(ticksPerRevolution)
+end
+
+--- Drive the crank-data-dumping utility. Call on every frame.
+local function update()
+    if not usingcrank then pd.getCrankTicks(1) end
+    usingcrank = false
+end
+
+crankhandler = {
+    name = "crankhandler",
+    getCrankTicks = getCrankTicks,
+    update = update
+}
+crankhandler = utils.makeReadOnly(crankhandler)
+return crankhandler

--- a/app/utils/crankhandler.lua
+++ b/app/utils/crankhandler.lua
@@ -14,7 +14,7 @@ local function getCrankTicks(ticksPerRevolution)
     return pd.getCrankTicks(ticksPerRevolution)
 end
 
---- Drive the crank-data-dumping utility. Call on every frame.
+--- Drive the crank-data-dumping utility.
 local function update()
     if not usingcrank then pd.getCrankTicks(1) end
     usingcrank = false

--- a/app/utils/debugger.lua
+++ b/app/utils/debugger.lua
@@ -78,7 +78,7 @@ function drawLog ()
 end
 
 --TODO need to rename this to draw..... despite naming clash..
--- bounds(sprite) visualizes the rectangular bounds of the sprite.
+-- Visualizes the rectangular bounds of the sprite.
 function illustrateBounds (sprite)
     gfx.pushContext(illImg)
         gfx.drawRect(sprite:getBounds())

--- a/app/utils/debugger.lua
+++ b/app/utils/debugger.lua
@@ -11,8 +11,8 @@ local type = type
 local pairs = pairs
 local fmod = math.fmod -- TODO may be able to replace this w % modulo lua operator?
 
-local W_SCREEN <const> = configs.W_SCREEN
-local H_SCREEN <const> = configs.H_SCREEN
+local W_SCREEN <const> = W_SCREEN
+local H_SCREEN <const> = H_SCREEN
 local W_LEFT_MARGIN <const> = 2
 local H_LINE <const> = 16
 local NUM_LINES <const> = 15 -- 240/16 (screen height / line height)

--- a/app/utils/utils.lua
+++ b/app/utils/utils.lua
@@ -22,6 +22,7 @@ end
 
 ---TODO DEBUG
 ---     1. when no proxy is used (ie. setmetatable(t, mt)), class instances become readonly
+---     2. __newindex triggers for values present in the table
 ---TODO dont need to return a table if we dont use a proxy here; refactor in all files that use this func
 --- Prevents adding new keys.
 --- Not true readonly, as k-v reassignment is unfortunately still permitted.
@@ -55,10 +56,12 @@ function makeReadOnly(t, name)
         if t.name then name = t.name
         else name = "<unknown table name>" end
     end
-    local msg = name .. " read-only; forbidden to write to it directly. Rejected key: "
     
     mt.__newindex = function(t,k,v)
-        _G.error(msg .. k)
+        local msg = name .. " read-only; forbidden to write to it directly."
+        msg = msg .. " Rejected key " .. k
+        if v then msg = msg .. " has value " .. v end
+        _G.error(msg)
     end
 
     return proxy

--- a/templates/template-class.lua
+++ b/templates/template-class.lua
@@ -16,7 +16,6 @@ local pd <const> = playdate
 local d <const> = debugger
 local gfx <const> = pd.graphics
 local utils <const> = utils
-local configs <const> = configs
 local d <const> = debugger
 --local externalfunc <const> = somepkg.func --TODO any other external vars go here
 


### PR DESCRIPTION
# Additions
- System menu button for resetting pom count
- System menu button for opening/closing config menu (which can also be closed by button input)
- Option for enabled UIElement parent to automatically enable its children
- Snoozing can be disabled by user
- Snooze duration user-configurable
- Poms per cycle (long break) user-configurable
- Elapsed poms can be saved between app closures. User-configurable behaviour.

# Refactors
- Key global constants accessible from global env
- List uses class `orientations` enum for configuring layout
- Textbox can be initialized with text
- New `crankhandler` pkg manages the discarding of crank data when it is not needed

# Fixes
- Snoozed work timers weren't being counted as completed poms