### PR TITLE
Refactor Timer: seperate data from visualizer, leverage UIElement for clock face

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The app is now useable in the simulator, if you would like to use it as a deskto
 ### Replace notification sound
 
 1. Create and export your sound according to [playdate specs for sound **samples**](https://sdk.play.date/1.13.1/Inside%20Playdate.html#M-sound).
-2. In `app/gconsts.lua`, modify the relevant `SOUND.notif_[timer type].path` string to point to your sound. You can modify the sound's volume here as well: set `SOUND.notif_[timer type].vol` to a float value in [0,1].
+2. In `app/gconsts.lua`, modify the relevant `SOUND.notif_[timer type].path` string to point to your sound. You can modify the sound's volume here as well: set `SOUND.notif_[timer type].volume` to a float value in [0,1].
 3. Compile and run the app as per the installation instructions above.
 
 Note that some samples may sound significantly different, even *bad*, on the playdate hardware. Lowering sound volume can help.

--- a/app/gconsts.lua
+++ b/app/gconsts.lua
@@ -34,19 +34,19 @@ SOUND.notif_workToBreak = {
     path = SOUND.notifPathPrefix ..
         "06 When Your Eyes Meet From Across the Bar"
         .. SOUND.notifPathSuffix,
-    vol = 0.9
+    volume = 0.9
 }
 SOUND.notif_breakToWork = {
     path = SOUND.notifPathPrefix ..
         "01 Into the Maelstrom"
         .. SOUND.notifPathSuffix,
-    vol = 0.9
+    volume = 0.9
 }
 SOUND.notif_fromSnooze = {
     path = SOUND.notifPathPrefix ..
         "03 Bittersweet"
         .. SOUND.notifPathSuffix,
-    vol = 0.9
+    volume = 0.9
 }
 SOUND.timerButtonSelected = { -- TODO needs export
     paths = {
@@ -57,7 +57,7 @@ SOUND.timerButtonSelected = { -- TODO needs export
         long = SOUND.uiPathPrefix ..
             "FUI Cursor Blunt"         --"FUI Button Pitch Jump"
     },
-    vol = 0.7
+    volume = 0.7
 }
 SOUND.timerButtonPressed = {
     paths = {
@@ -68,29 +68,29 @@ SOUND.timerButtonPressed = {
         long = SOUND.uiPathPrefix ..
             "LOAD_CASSETTE_07"
     },
-    vol = 1
+    volume = 1
 }
 SOUND.preSwitchLED = {
     path = SOUND.uiPathPrefix ..
         "tape_playback_02",
-    vol = 1
+    volume = 1
 }
 SOUND.crankDialSwitch = {
     closing = {
         path = SOUND.uiPathPrefix ..
             "Mechanical Motion Short slow",
-        vol = 1
+        volume = 1
     },
     closed = {
         path = SOUND.uiPathPrefix ..
             "BUTTON_STOP_05",
-        vol = 0.7
+        volume = 0.7
     }
 }
 SOUND.postSwitchLED = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }
 SOUND.timerLoaded = {
     paths = {
@@ -101,35 +101,35 @@ SOUND.timerLoaded = {
         long = SOUND.uiPathPrefix ..
             ""
     },
-    vol = 1
+    volume = 1
 }
 SOUND.runToMenu = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }
 SOUND.doneToMenu = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }
 SOUND.backButton = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }
 SOUND.nextButton = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }
 SOUND.snoozeButton = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }
 SOUND.pomsFull = {
     path = SOUND.uiPathPrefix ..
         "",
-    vol = 1
+    volume = 1
 }

--- a/app/main.lua
+++ b/app/main.lua
@@ -240,7 +240,6 @@ function toRun(t, duration)
 end
 
 function toDone()
-    currentTimer:notify()
     currentTimer:stop() --currentTimer:remove()
     
     timerCompleted = true
@@ -285,7 +284,6 @@ function pd.update()
     if stateIsLOADING() then
         --d.log("hit stateIsLOADING")
         pd.ui.crankIndicator:update()
-        d.log("updated crankIndicator")
         if pd.buttonJustPressed(A) then
             splashSprite:remove()
             toMenu()

--- a/app/musicmanager.lua
+++ b/app/musicmanager.lua
@@ -1,0 +1,85 @@
+---TODO pkg 'musicmanager' handles the playing of not-SFX music, specifically, notification sounds.
+
+local pd <const> = playdate
+local d <const> = debugger
+local snd <const> = pd.sound
+local utils <const> = utils
+local type <const> = type
+local pairs <const> = pairs
+
+local fileplayer = nil
+local tracklist = nil
+local currentTrackName = nil
+
+--- Play a track.
+---@param trackName name of the track to play
+local function play(trackName)
+    if not trackName then d.log("no trackName provided to play()") return end
+    local trackData = tracklist[trackName]
+    if not trackData or not trackData.path then d.log("missing critical data for music track "..trackName) return end
+
+    fileplayer:pause()          -- calling stop() would trigger callback, if any
+    fileplayer:load(trackData.path)
+    currentTrackName = trackName
+    if trackData.volume then fileplayer:setVolume(trackData.volume) end
+    if trackData.callback then
+        fileplayer:setFinishCallback(trackData.callback)
+        fileplayer:play(1)      -- play once, so that callback can get called after
+    else
+        fileplayer:play(0)      -- loop endlessly
+    end
+end
+
+--- Initialize the music manager
+local function init()
+    fileplayer = snd.fileplayer.new()
+    fileplayer:setStopOnUnderrun(false)
+    tracklist = {}
+end
+
+--- Add one or more tracks to the tracklist.
+---@param tracks table of (name, {path, volume, callback}) tuples to add to the tracklist, OR
+---              string name of the single track to add
+---@param path string (optional) path to the single track to add
+---@param volume float (optional) volume of the track, in range [0,1]
+---@param callback function (optional) to call when track completes one playthrough
+local function add(tracks, path, volume, callback)
+    local function addOne(name, path, volume, callback)
+        if not path then d.log("no path provided for "..name.." track") return end
+        if not volume then volume = 1 end
+
+        tracklist[name] = {
+            path = path,
+            volume = volume,
+            callback = callback     -- may be nil
+        }
+    end
+
+    if type(tracks) == "table" then
+        for name, data in pairs(tracks) do
+            addOne(name, data.path, data.volume, data.callback)
+        end
+    elseif type(tracks) == "string" then addOne(tracks, path, callback)
+    else d.log("unrecognized arg1 type for musicmanager.add")
+    end
+end
+
+local function update()
+    if stateIsDONE_TIMER() then -- TODO should be DONE_TIMER
+        local trackName = getTimerName()
+        if currentTrackName == trackName and fileplayer:isPlaying() then
+            return
+        end
+        play(trackName)
+    else
+        if fileplayer:isPlaying() then fileplayer:pause() end
+    end
+end
+
+musicmanager = {
+    init = init,
+    add = add,
+    update = update
+}
+musicmanager = utils.makeReadOnly(musicmanager)
+return musicmanager

--- a/app/timer.lua
+++ b/app/timer.lua
@@ -22,8 +22,6 @@ local Timer <const> = Timer
 local MSEC_PER_SEC <const> = 1000
 local SEC_PER_MIN <const> = 60
 
-local notifSound = nil
-
 local _ENV = P
 name = "timer"
 
@@ -38,11 +36,13 @@ local function convertToClock(msec)
     return min, sec
 end
 
+---[[
 --- Notifies user that timer is complete
 function Timer:notify()
     --d.log("notification pushed")
     if self._notifSound then self._notifSound:play(0) end
 end
+--]]
 
 --- Initializes, but does not start, a Timer.
 ---@param name string timer's name for graybox and debugging
@@ -71,38 +71,36 @@ end
 --]]
 -- Timer:update() draws the current time in the timer countdown
 function Timer:update()
+    --TODO rm
+    if _G.stateIsRUN_TIMER() then self:setVisible(true)
+    else self:setVisible(false)
+    end
+
     --TODO refactor when pd.timer.pause() is fixed
-    if stateIsRUN_TIMER() then
-        local msec
-        if self._isPaused then msec = self._duration --TODO rm workaround
-        elseif self._timer then msec = self._timer.value
-        else
-            d.log(self.name .. "._timer is nil on RUN")
-            return
-        end
+    local msec
+    if self._isPaused then msec = self._duration --TODO rm workaround
+    elseif self._timer then msec = self._timer.value
+    else
+        d.log(self.name .. "._timer is nil on RUN")
+        return
+    end
 
-        -- if timer has completed
-        if msec <= 0 then
-            _G.toDone()
-        else
-            local min, sec = convertToClock(msec)
-            -- debugger.log("min: " .. min .. " sec: " .. sec)
-            -- debugger.log(self._timer.value)
-            local timeString = ""
-            if min < 10 then timeString = "0" end
-            timeString = timeString .. min .. ":"
-            if sec < 10 then timeString = timeString .. "0" end
-            timeString = timeString .. sec
+    -- if timer has completed
+    if msec <= 0 then
+        _G.toDone()
+    else
+        local min, sec = convertToClock(msec)
+        -- debugger.log("min: " .. min .. " sec: " .. sec)
+        -- debugger.log(self._timer.value)
+        local timeString = ""
+        if min < 10 then timeString = "0" end
+        timeString = timeString .. min .. ":"
+        if sec < 10 then timeString = timeString .. "0" end
+        timeString = timeString .. sec
 
-            gfx.pushContext(self._img)
-                gfx.clear(COLOR_CLEAR)
-                gfx.drawText("*"..timeString.."*", 0, 0)
-            gfx.popContext()
-        end
-    elseif stateIsDONE_TIMER() then --TODO actually this doesn't need to be done by timer.lua! refactor this whole if/else out.
         gfx.pushContext(self._img)
-        gfx.clear()
-        gfx.drawText("*DONE*", 0, 0)
+            gfx.clear(COLOR_CLEAR)
+            gfx.drawText("*"..timeString.."*", 0, 0)
         gfx.popContext()
     end
 
@@ -174,6 +172,7 @@ function Timer:isStopped()
 end
 --]]
 
+---[[
 --- Set the sound to be played when a timer finishes
 ---@param sound pd.sound.sampleplayer or pd.sound.fileplayer
 ---@param volume (optional) float
@@ -187,6 +186,7 @@ function Timer:setNotifSound(sound, volume)
     end
     if volume and self._notifSound then self._notifSound:setVolume(volume) end
 end
+--]]
 
 --- Set the duration the timer should run for (in minutes).
 ---@param mins integer duration

--- a/app/timer.lua
+++ b/app/timer.lua
@@ -1,4 +1,4 @@
--- timer provides value-based timers, rendered as sprites
+-- pkg Timer provides value-based timers that work around the pausing bug in the Playdate SDK
 local P = {}; local _G = _G
 timer = {}
 
@@ -8,120 +8,67 @@ import "CoreLibs/easing" --TODO rm
 
 local pd <const> = playdate
 local d <const> = debugger
-local gfx <const> = pd.graphics
+local tmr <const> = pd.timer
 local utils <const> = utils
 local floor <const> = math.floor -- TODO may be able to replace this w // floor division lua operator?
-local stateIsRUN_TIMER <const> = stateIsRUN_TIMER
-local stateIsDONE_TIMER <const> = stateIsDONE_TIMER
-local COLOR_CLEAR <const> = COLOR_CLEAR
+local pairs <const> = pairs
 
 -- Timer packs a timer with its UI.
-class('Timer').extends(gfx.sprite)
+class('Timer').extends()
 local Timer <const> = Timer
+local _ENV = P
+name = "timer"
 
 local MSEC_PER_SEC <const> = 1000
 local SEC_PER_MIN <const> = 60
 
-local _ENV = P
-name = "timer"
+local activeTimers = {}
 
---- Converts the msec argument into the clock time, rounded down
----@param msec integer milliseconds
----@return integer minutes
----@return integer seconds remaining after msec is converted to min 
-local function convertToClock(msec)
-    local sec = msec / MSEC_PER_SEC
-    local min = floor(sec / SEC_PER_MIN)
-    sec = floor(sec - min * SEC_PER_MIN)
-    return min, sec
+function update()
+    tmr.updateTimers()
+    for _, timer in pairs(activeTimers) do
+        timer:update()
+    end
 end
 
 --- Initializes, but does not start, a Timer.
 ---@param name string timer's name for graybox and debugging
-function Timer:init(name)
+---@param callback function (optional) to call when timer completes
+function Timer:init(name, callback)
     -- TODO give each timer a name
     Timer.super.init(self)
     self.name = name
+    self._callback = callback
 
     self._duration = 0.0 -- float timer duration in msec
-    self._img = gfx.image.new(200, 150, COLOR_CLEAR)
-    self:setImage(self.img)
-    
+
     self._timer = nil -- "value-based" pd timer w linear interpolation
     self._isPaused = false -- true iff the timer is paused
-
-    self:setCenter(0, 0) --anchor top-left
 end
 
---[[
-    :update() is called before :draw is called on all sprites
-    Suspected conditions for redrawing a sprite if getAlwaysRedraw() == false
-        - associated gfx.image has changed
-        - sprite has had some transform applied to it
-    So if we need to update a sprite every frame, do something in its :update()
---]]
--- Timer:update() draws the current time in the timer countdown
+--TODO desc
+--TODO how to drive updates now that we don't inherit from sprite
 function Timer:update()
-    --TODO rm
-    if stateIsRUN_TIMER() then self:setVisible(true)
-    else self:setVisible(false)
-    end
-
-    --TODO refactor when pd.timer.pause() is fixed
-    local msec
-    if self._isPaused then msec = self._duration --TODO rm workaround
-    elseif self._timer then msec = self._timer.value
-    else
-        d.log(self.name .. "._timer is nil on RUN")
-        return
-    end
-
     -- if timer has completed
-    if msec <= 0 then
-        _G.toDone()
-    else
-        local min, sec = convertToClock(msec)
-        -- debugger.log("min: " .. min .. " sec: " .. sec)
-        -- debugger.log(self._timer.value)
-        local timeString = ""
-        if min < 10 then timeString = "0" end
-        timeString = timeString .. min .. ":"
-        if sec < 10 then timeString = timeString .. "0" end
-        timeString = timeString .. sec
-
-        gfx.pushContext(self._img)
-            gfx.clear(COLOR_CLEAR)
-            gfx.drawText("*"..timeString.."*", 0, 0)
-        gfx.popContext()
+    if self._timer and self._timer.value <= 0 then
+        self:stop()
+        self._callback()
     end
-
-    --DEBUG doing this prevents the sprite from auto-refreshing when self._img changes
-    --TODO set a larger font instead of upscaling default text
-    self:setImage(self._img:scaledImage(4))
-
-    Timer.super.update(self)
-    --d.illustrateBounds(self)
 end
 
 --- Stop a Timer.
 --- Stopped timers can be restarted by calling start().
 function Timer:stop()
+    activeTimers[self.name] = nil
     self._timer = nil
     self._isPaused = false
-end
-
---- Stop a Timer and remove its sprite.
---- Removed timers must be added back with add() before they can start().
-function Timer:remove()
-    d.log("removing timer "..self.name)
-    self:stop()
-    Timer.super.remove(self)
 end
 
 --- Pause a Timer.
 --- Paused timers can be continued with start().
 function Timer:pause()
     if self._timer then
+        activeTimers[self.name] = nil
         -- self._timer:pause() -- doesn't work; when started the value 'fast-forwards' according to the current time
         self._isPaused = true
 
@@ -139,14 +86,10 @@ function Timer:start()
     if self._timer then
         d.log("forbidden to reset timer " .. self.name)
     else
-        self._timer = pd.timer.new(self._duration, self._duration, 0)
+        self._timer = tmr.new(self._duration, self._duration, 0)
         self._isPaused = false
+        activeTimers[self.name] = self
     end
-end
-
---- Returns true if this timer is paused.
-function Timer:isPaused()
-    return self._isPaused
 end
 
 --[[ Won't work while pd.timer:pause() is buggy
@@ -168,6 +111,30 @@ end
 function Timer:setDuration(mins)
     self._duration = (mins + 0.0) * SEC_PER_MIN * MSEC_PER_SEC
 end
+
+--- Returns true if this timer is active (ie. has been started and is not paused)
+function Timer:isActive()
+    if activeTimers[self.name] == self then return true
+    else return false end
+end
+
+--- Get the time remaining in clock time
+---@param msec integer milliseconds
+---@return integer minutes
+---@return integer seconds remainder
+function Timer:getClockTime()
+    --TODO refactor when pd.timer.pause() is fixed
+    local msec = 0
+    if self._isPaused then msec = self._duration --TODO rm workaround
+    elseif self._timer then msec = self._timer.value
+    end
+    
+    local sec = msec / MSEC_PER_SEC
+    local min = floor(sec / SEC_PER_MIN)
+    sec = floor(sec - min * SEC_PER_MIN)
+    return min, sec
+end
+
 
 local _ENV = _G
 timer = utils.makeReadOnly(P)

--- a/app/timer.lua
+++ b/app/timer.lua
@@ -36,14 +36,6 @@ local function convertToClock(msec)
     return min, sec
 end
 
----[[
---- Notifies user that timer is complete
-function Timer:notify()
-    --d.log("notification pushed")
-    if self._notifSound then self._notifSound:play(0) end
-end
---]]
-
 --- Initializes, but does not start, a Timer.
 ---@param name string timer's name for graybox and debugging
 function Timer:init(name)
@@ -57,7 +49,6 @@ function Timer:init(name)
     
     self._timer = nil -- "value-based" pd timer w linear interpolation
     self._isPaused = false -- true iff the timer is paused
-    self._notifSound = nil -- sound to play when notifying
 
     self:setCenter(0, 0) --anchor top-left
 end
@@ -72,7 +63,7 @@ end
 -- Timer:update() draws the current time in the timer countdown
 function Timer:update()
     --TODO rm
-    if _G.stateIsRUN_TIMER() then self:setVisible(true)
+    if stateIsRUN_TIMER() then self:setVisible(true)
     else self:setVisible(false)
     end
 
@@ -115,7 +106,6 @@ end
 --- Stop a Timer.
 --- Stopped timers can be restarted by calling start().
 function Timer:stop()
-    if self._notifSound then self._notifSound:stop() end
     self._timer = nil
     self._isPaused = false
 end
@@ -172,21 +162,6 @@ function Timer:isStopped()
 end
 --]]
 
----[[
---- Set the sound to be played when a timer finishes
----@param sound pd.sound.sampleplayer or pd.sound.fileplayer
----@param volume (optional) float
-function Timer:setNotifSound(sound, volume)
-    if not sound then
-        d.log("missing sound arg for timer.setNotifSound")
-    elseif not sound.play or not sound.stop then
-        d.log("attempting to set unplayable notif sound", sound)
-    else
-        self._notifSound = sound
-    end
-    if volume and self._notifSound then self._notifSound:setVolume(volume) end
-end
---]]
 
 --- Set the duration the timer should run for (in minutes).
 ---@param mins integer duration

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -222,8 +222,8 @@ local function initCrankDialCircuit()
         switch.fg_anim:play(-1, 1, animation.bookmarks.first)
         crankDialSwitchIsClosed = false
     end
-    switch:setSound("held", snd.sampleplayer.new(SOUND.crankDialSwitch.closing.path), SOUND.crankDialSwitch.closing.vol)
-    switch:setSound("locked", snd.sampleplayer.new(SOUND.crankDialSwitch.closed.path), SOUND.crankDialSwitch.closed.vol)
+    switch:setSound("held", snd.sampleplayer.new(SOUND.crankDialSwitch.closing.path), SOUND.crankDialSwitch.closing.volume)
+    switch:setSound("locked", snd.sampleplayer.new(SOUND.crankDialSwitch.closed.path), SOUND.crankDialSwitch.closed.volume)
     switch.pressedAction = function ()
         switch.fg_anim:play(1, 0, animation.bookmarks.last,
         function ()
@@ -243,7 +243,7 @@ local function initCrankDialCircuit()
     preSwitchLED.isSelected = function() return true end
     preSwitchLED.getDialChange = crankhandler.subscribe()
     preSwitchLED:setMode(dial.visualizers.animation)
-    preSwitchLED:setSound("dialing", snd.fileplayer.new(SOUND.preSwitchLED.path), SOUND.preSwitchLED.vol) --would prefer a sampleplayer here
+    preSwitchLED:setSound("dialing", snd.fileplayer.new(SOUND.preSwitchLED.path), SOUND.preSwitchLED.volume) --would prefer a sampleplayer here
     postSwitchLED:setForeground(postSwitchLEDImagetable, 16)
     postSwitchLED:setPosition(10, 34)
     postSwitchLED.isSelected = getCrankDialCircuitClosure
@@ -278,8 +278,8 @@ local function init(timers)
 
             local button = Button({name .. "Button", BUTTON_WIDTH_L, BUTTON_HEIGHT_M})
             timerSelectButtons[name] = button
-            button:setSound("touched", snd.sampleplayer.new(SOUND.timerButtonPressed.paths[name]), SOUND.timerButtonPressed.vol)
-            button:setSound("selected", snd.sampleplayer.new(SOUND.timerButtonSelected.paths[name]), SOUND.timerButtonSelected.vol)
+            button:setSound("touched", snd.sampleplayer.new(SOUND.timerButtonPressed.paths[name]), SOUND.timerButtonPressed.volume)
+            button:setSound("selected", snd.sampleplayer.new(SOUND.timerButtonSelected.paths[name]), SOUND.timerButtonSelected.volume)
             button.isPressed = function() return pd.buttonJustPressed(A) end
             button:setBackground(function(width, height)
                 local w_line = 8 -- must be even
@@ -375,6 +375,11 @@ local function init(timers)
 
     fillTimersMenu(timersMenu, timers, cursor)
 
+    local timerDoneSign = UIElement({"timerDoneSign", 300, 100}) -- simple textbox
+    timerDoneSign:setText("NEXT")
+    timerDoneSign:setPosition(MARGIN, MARGIN)
+    timerDoneSign:setEnablingCriteria(stateIsDONE_TIMER)
+    timerDoneSign:forceConfigured()
 
     --- Initialize a button that sits directly above the A or B buttons
     ---@param name string button name

--- a/app/uimanager.lua
+++ b/app/uimanager.lua
@@ -434,12 +434,7 @@ local function init(timers)
         display:setUnit(unit)
 
         local prevScore = 0
-        display.getDialChange = function()
-            local currentScore = scoringFunc()
-            local scoreDiff = currentScore - prevScore
-            prevScore = currentScore
-            return scoreDiff
-        end
+        display.getDialValue = scoringFunc
         return display
     end
 

--- a/templates/template-class.lua
+++ b/templates/template-class.lua
@@ -1,0 +1,55 @@
+--[[TODO rm
+    This is a template class.
+    Features a class namespace + pseudo-readonly access control on pkg and instances
+    Find+Replace (case-sensitive) 'Class' with the Classname
+    Find+Replace 'package' with the classname (lowercase)
+--]]
+
+---TODO pkg 'package' DESC
+
+-- pkg header: define pkg namespace
+local P = {}; local _G = _G
+package = {}
+
+local pd <const> = playdate
+local d <const> = debugger
+local gfx <const> = pd.graphics
+local utils <const> = utils
+--local externalfunc <const> = somepkg.func --TODO any other external vars go here
+
+---TODO Class desc
+class('Class').extends(gfx.sprite)
+local Class <const> = Class
+local _ENV = P      -- enter pkg namespace
+name = "package"
+
+--local localstatic <const> = val --TODO non-imported statics go here
+
+--local localvar = val --TODO local vars go here
+
+--local function localfunc() end --TODO local funcs go here
+
+--- Initializes a new Class instance.
+---@param name string instance name for debugging
+function Class:init(name)
+    Class.super.init(self) --should always be at top of init func
+    
+    self.name = name
+--    self.property = val   -- TODO instance properties. Public
+
+    self:setCenter(0, 0) --anchor top-left
+    self = utils.makeReadOnly(self, "Class instance")
+end
+
+---TODO desc
+function Class:update()
+    Class.super.update(self)
+    --d.illustrateBounds(self)
+
+    
+end
+
+-- pkg footer: pack and export the namespace.
+local _ENV = _G
+package = utils.makeReadOnly(P)
+return package


### PR DESCRIPTION
Separates the Timer data backend from its audiovisual frontend rendering.

## Changes
- Timer clock face is now a Dial UIElement; it is capable of animating into position, disabling itself when app state changes, etc.
- Adds `getDialValue`, in addition to preexisting `getDialChange`, thereby enabling Dials to visualize absolute value from a data source, in addition to change-in-value.
- Timer clock face only shows minutes, as specified in redesign goals.
- Adds `musicmanager.lua`, which handles background music tracks such as the timer-completion notification music.
- Improves data structure of UI appearance parameters near the top of `uimanager.lua`

## Fixes
- Restores `template.lua`, which was mistakenly deleted